### PR TITLE
Move tmux session management to host launcher

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,7 +10,7 @@
 #
 #   2. PROJECT — molim-specific tooling. Replaceable per project.
 #
-# Hardening (firewall enforcement, capability drops, read-only root) is
+# [TODO] Hardening (firewall enforcement, capability drops, read-only root) is
 # not yet implemented.
 # ======================================================================
 
@@ -159,9 +159,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Reuse the `node` user (UID/GID 1000) that ships with the base image.
 # Pre-create /workspace owned by node so the entrypoint's git clone can
 # write into it. WORKDIR alone would create /workspace as root.
-# TODO Phase 3: when /workspace becomes a tmpfs mount, this RUN line
-# becomes redundant (tmpfs uid/gid is set by the mount flags) and
-# should be removed.
+# [TODO] when /workspace becomes a tmpfs mount, this RUN line becomes
+# redundant (tmpfs uid/gid is set by the mount flags) and should be removed.
 RUN mkdir -p /workspace && chown -R node:node /workspace
 USER node
 WORKDIR /workspace

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 # ======================================================================
-# molim development environment image — initial skeleton (Phase 2, Step 4)
+# molim development environment image
 #
 # This Dockerfile is organized into two logical sections:
 #
@@ -11,8 +11,7 @@
 #   2. PROJECT — molim-specific tooling. Replaceable per project.
 #
 # Hardening (firewall enforcement, capability drops, read-only root) is
-# added at Phase 3. Entrypoint logic (clone, branch checkout, exec
-# claude) is added at Step 6.
+# not yet implemented.
 # ======================================================================
 
 
@@ -70,7 +69,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         git \
-        tmux \
         jq \
         bubblewrap \
         socat \
@@ -172,8 +170,5 @@ WORKDIR /workspace
 # final command after bootstrap. CMD is overridable at `docker run` time
 # for troubleshooting (e.g., `docker run ... molim-devenv ls /workspace`
 # bootstraps and runs ls instead of bash).
-#
-# Step 6: CMD = bash (interactive shell after bootstrap).
-# Step 7: CMD will become tmux + claude.
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD ["bash"]
+CMD ["claude"]

--- a/.devcontainer/entrypoint.sh
+++ b/.devcontainer/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ======================================================================
-# entrypoint.sh — Claude Code dev environment bootstrap (Phase 2, Step 6)
+# entrypoint.sh — Claude Code dev environment bootstrap
 #
 # Runs as the container's ENTRYPOINT. Receives configuration via env
 # vars from the launcher (claude-dev.sh on the host):
@@ -230,6 +230,5 @@ if [[ "${COMMITS_AHEAD}" -gt 0 ]]; then
 fi
 echo
 
-# Hand off to whatever the image's CMD specifies (bash for Step 6,
-# tmux+claude for Step 7).
+# Hand off to the image's CMD (claude).
 exec "$@"

--- a/docs/CLAUDE-DEV-ENVIRONMENT.md
+++ b/docs/CLAUDE-DEV-ENVIRONMENT.md
@@ -29,6 +29,7 @@ Prerequisites:
   required.
 - Bash.
 - Ghostty (or another GPU-capable terminal emulator).
+- `tmux` (session manager; keeps the container alive across terminal crashes).
 - `libsecret-tools` (provides `secret-tool` for keyring access).
 - `seahorse` (GUI for browsing and auditing the keyring).
 - An active GNOME (or compatible Secret Service) login session, so the keyring is unlocked.
@@ -204,7 +205,7 @@ One container instance corresponds to one in-flight feature:
 | One feature workflow | One Claude Code session |
 | One Claude Code session | One `claude` process |
 | One `claude` process | One container |
-| One container | One terminal tab (or `tmux` window) |
+| One container | One host `tmux` window |
 
 Claude Code subagents run inside the parent `claude` process and do not
 require their own containers.
@@ -225,11 +226,12 @@ container; there is no "resume previous container" path.
 PTY (`docker run -it`), `TERM=xterm-256color`, and a UTF-8 locale
 (`LANG=en_US.UTF-8`, `locales` package installed in the image).
 
-**Survivability.** `claude` runs inside a `tmux` session inside the
-container, so accidental terminal closes (lid close, X disconnect, SSH
-drop) do not kill the session. Reattach with
-`docker exec -it <container> tmux attach`. Survivability ends when the
-container exits, by design.
+**Survivability.** The launcher creates a named host `tmux` session and
+runs `docker run` inside it. Ghostty attaches to that session. If Ghostty
+crashes or is closed, the host tmux daemon keeps `docker run` alive and the
+container continues running. Reattach from any new terminal with
+`tmux attach -t <session-name>` (see Launcher section for the naming
+scheme). Survivability ends when the container exits, by design.
 
 ---
 
@@ -582,7 +584,7 @@ target; it is not propagated into the container.
 
 1. Validate the argument: zero or one positional argument; if present,
    must be a positive integer Issue ID.
-2. Verify host prerequisites (`docker`, `secret-tool`); fail fast with
+2. Verify host prerequisites (`docker`, `secret-tool`, `tmux`); fail fast with
    installation hints if anything is missing.
 3. Source `scripts/claude-dev.env`; verify required variables are set.
 4. Read the pinned image digest from `.devcontainer/image.digest`.
@@ -591,14 +593,22 @@ target; it is not propagated into the container.
    - `secret-tool lookup service claude-dev account github-token`
    Fail fast with a bootstrap-procedure pointer if either is empty.
 6. Detect the host timezone from `/etc/timezone` or `/etc/localtime`.
-7. `docker run --rm -it` with the pinned image, an interactive TTY,
-   resource limits (`--memory`, `--cpus`), capability drop
-   (`--cap-drop=ALL` plus `--cap-add=NET_ADMIN` for firewall init),
+7. Assemble the `docker run --rm -it` invocation with the pinned image,
+   an interactive TTY, resource limits (`--memory`, `--cpus`), capability
+   drop (`--cap-drop=ALL` plus `--cap-add=NET_ADMIN` for firewall init),
    `--security-opt no-new-privileges`, read-only root filesystem with
    tmpfs for required writable paths, and the env vars `GH_OWNER`,
    `GH_REPO`, `CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `TZ`, plus
    `ISSUE_ID` when an Issue ID was provided. No bind mounts.
-8. On exit, print the final `git status` and `git log origin/main..HEAD`
+8. Launch the container inside a host tmux session:
+   - If already running inside tmux (`$TMUX` is set): exec `docker run`
+     directly — no nesting.
+   - Otherwise: generate a 4-character alphanumeric suffix, build a
+     session name (`{GH_OWNER}-{GH_REPO}-{ISSUE_ID}-{suffix}` when an
+     Issue ID was provided, `{GH_OWNER}-{GH_REPO}-{suffix}` otherwise),
+     and exec `tmux new-session -s <name> docker run ...`. The session
+     name is printed so the Project Owner can use it with `tmux attach`.
+9. On exit, print the final `git status` and `git log origin/main..HEAD`
    from the container so the Project Owner sees what was pushed and what
    was not before the container is destroyed.
 
@@ -632,7 +642,7 @@ with an Issue ID.
 5. Install project development tooling and and dependencies (in case of `uv` and Python project via `uv sync --frozen` against the project's locked manifests. `uv` resolves and installs Python itself (per the project's `.python-version` / `pyproject.toml`) at this step; no Python is baked into the image).
 6. Print a brief summary: Issue title (if any), current phase, branch
    state (fresh start vs resuming, commits ahead of `main` if resuming).
-7. Start a `tmux` session and exec `claude` inside it.
+7. Exec `claude` directly.
 
 **Branch lookup uses GitHub's first-class linkage**, not the branch
 naming convention. The SDLC creates the link when the branch is created

--- a/docs/CLAUDE-DEV-ENVIRONMENT.md
+++ b/docs/CLAUDE-DEV-ENVIRONMENT.md
@@ -205,7 +205,7 @@ One container instance corresponds to one in-flight feature:
 | One feature workflow | One Claude Code session |
 | One Claude Code session | One `claude` process |
 | One `claude` process | One container |
-| One container | One host `tmux` window |
+| One container | One host `tmux` session |
 
 Claude Code subagents run inside the parent `claude` process and do not
 require their own containers.

--- a/scripts/claude-dev.sh
+++ b/scripts/claude-dev.sh
@@ -13,10 +13,10 @@
 #   claude-dev.sh -- <cmd> [args...]         # no issue; override command
 #   claude-dev.sh <issue-id> -- <cmd> [args] # specific Issue; override command
 #
-# The default command is whatever the image's CMD specifies (currently
-# bash; will become tmux + claude in Step 7). The override is intended
-# for troubleshooting (e.g., running `uv run pytest` against a fresh
-# clone without entering an interactive session).
+# The default command is whatever the image's CMD specifies (claude).
+# The override is intended for troubleshooting (e.g., running
+# `uv run pytest` against a fresh clone without entering an interactive
+# session).
 #
 # [TODO] Hardening flags, GHCR pull, digest pinning, entrypoint logic, and
 # pre-exit reporting are added in later steps.
@@ -120,6 +120,7 @@ require_tool() {
 
 require_tool docker      "Install Docker Engine (https://docs.docker.com/engine/install/)."
 require_tool secret-tool "Install libsecret-tools (apt install libsecret-tools)."
+require_tool tmux        "Install tmux (apt install tmux)."
 
 # ----------------------------------------------------------------------
 # Load and validate claude-dev.env
@@ -203,6 +204,23 @@ if [[ ${#CMD_OVERRIDE[@]} -gt 0 ]]; then
 fi
 
 # ----------------------------------------------------------------------
-# Run
+# Run — inside a named host tmux session for survivability.
+#
+# If Ghostty (or any other terminal) crashes, the tmux session on the
+# host keeps docker run alive. Reattach with: tmux attach -t <name>
+#
+# If already inside tmux ($TMUX is set), run docker directly to avoid
+# nesting sessions.
 # ----------------------------------------------------------------------
-exec docker "${DOCKER_ARGS[@]}"
+if [[ -n "${TMUX:-}" ]]; then
+    exec docker "${DOCKER_ARGS[@]}"
+else
+    SUFFIX=$(LC_ALL=C tr -dc 'a-zA-Z0-9' </dev/urandom | head -c 4)
+    if [[ -n "$ISSUE_ID" ]]; then
+        TMUX_SESSION="${GH_OWNER}-${GH_REPO}-${ISSUE_ID}-${SUFFIX}"
+    else
+        TMUX_SESSION="${GH_OWNER}-${GH_REPO}-${SUFFIX}"
+    fi
+    echo "tmux session: ${TMUX_SESSION}"
+    exec tmux new-session -s "${TMUX_SESSION}" docker "${DOCKER_ARGS[@]}"
+fi


### PR DESCRIPTION
## What this PR does

Refactors the Claude dev environment to run `docker run` inside a named host `tmux` session (created by the launcher) instead of inside a container-local `tmux` session. This improves survivability: if the terminal (Ghostty) crashes or closes, the host tmux daemon keeps the container alive, allowing reattachment from any new terminal.

**Key changes:**

1. **Launcher (`scripts/claude-dev.sh`):**
   - Added `tmux` to host prerequisites check
   - Generates a 4-character alphanumeric suffix and builds a session name: `{GH_OWNER}-{GH_REPO}-{ISSUE_ID}-{suffix}` (or without ISSUE_ID if not provided)
   - Launches `docker run` inside `tmux new-session` instead of directly
   - Detects if already running inside tmux (`$TMUX` set) and execs `docker run` directly to avoid nesting
   - Prints the session name so users can reattach with `tmux attach -t <name>`

2. **Container image (`Dockerfile`):**
   - Removed `tmux` from container dependencies (no longer needed inside container)
   - Changed `CMD` from `bash` to `claude` (the actual default command)

3. **Container entrypoint (`entrypoint.sh`):**
   - Removed logic that would start a tmux session inside the container
   - Now execs the CMD directly (which is `claude`)

4. **Documentation (`CLAUDE-DEV-ENVIRONMENT.md`):**
   - Updated survivability section to explain host-level tmux session management
   - Updated launcher section to document the new tmux session creation logic
   - Updated architecture table to clarify "One container | One host `tmux` window"
   - Updated prerequisites to list `tmux` as required on the host

**Survivability model:** Terminal crash → host tmux daemon keeps `docker run` alive → container continues running → user reattaches with `tmux attach -t <session-name>`. Container only exits by design (when the process inside exits).

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation
- [ ] CI / configuration

## Checklist

- [x] Code is formatted and linted
- [x] PR title is a clear, human-readable summary of the change
- [x] Documentation updated to reflect the new behavior

https://claude.ai/code/session_01R2vPDqhcshNWxh9N7Junkj