### PR TITLE
Decoupled project repo identity from gh's reserved env-var space.

### DIFF
--- a/.devcontainer/claude-dev/entrypoint.sh
+++ b/.devcontainer/claude-dev/entrypoint.sh
@@ -4,8 +4,14 @@
 #
 # Runs as the container's ENTRYPOINT. Receives configuration via env
 # vars from the launcher (claude-dev.sh on the host):
-#   GH_OWNER, GH_REPO            project identity
-#   GH_TOKEN                     GitHub Token (read/write per scoping)
+#   GITHUB_OWNER, GITHUB_REPO    project identity (logical names; the
+#                                entrypoint constructs the gh-recognized
+#                                GH_REPO=OWNER/REPO from these)
+#   GITHUB_TOKEN_                GitHub Token (read/write per scoping).
+#                                Trailing underscore is intentional: it
+#                                avoids gh's reserved GH_TOKEN/GITHUB_TOKEN
+#                                names so gh auth login works without the
+#                                pre-unset dance.
 #   CLAUDE_CODE_OAUTH_TOKEN      consumed later by claude itself
 #   TZ                           host timezone
 #   ISSUE_ID                     optional GitHub Issue number
@@ -72,9 +78,9 @@ require_env() {
     success "$text"
 }
 
-require_env GH_OWNER true
-require_env GH_REPO true
-require_env GH_TOKEN
+require_env GITHUB_OWNER true
+require_env GITHUB_REPO true
+require_env GITHUB_TOKEN_
 require_env CLAUDE_CODE_OAUTH_TOKEN
 require_env TZ true
 require_env CLAUDE_DEV_PROXY_SOCKET
@@ -96,7 +102,7 @@ fi
 section "Configuring shell prompt"
 
 configure_prompt() {
-    local context="${GH_REPO}"
+    local context="${GITHUB_REPO}"
 
     if [[ -n "${ISSUE_ID:-}" ]]; then
         context="${context} #${ISSUE_ID}"
@@ -513,17 +519,24 @@ start_proxy_bridge
 # Configure GitHub authentication via gh
 # This installs gh's git credential helper as a side effect, so both
 # `gh` and `git` work against github.com without further setup.
+#
+# GITHUB_TOKEN_ (with trailing underscore) is the launcher → container
+# contract; gh does not recognize it, so we can pipe it directly to
+# `gh auth login` without first unsetting a reserved env var. After
+# auth, the token lives in gh's credential helper config, so we drop
+# GITHUB_TOKEN_ from the environment.
 # ----------------------------------------------------------------------
 section "Configuring GitHub authentication"
 
-GH_TOKEN_TMP="$GH_TOKEN"
-# gh auth is not working properly with GH_TOKEN env var present, so need to move it to a temp var and unset.
-unset GH_TOKEN
-echo "$GH_TOKEN_TMP" | gh auth login --with-token --hostname github.com
-# After gh authentication, the token is stored in gh's credential helper config and the GH_TOKEN/GH_TOKEN_TMP env var is no longer needed.
-unset GH_TOKEN_TMP
+echo "$GITHUB_TOKEN_" | gh auth login --with-token --hostname github.com
+unset GITHUB_TOKEN_
 gh auth setup-git
 gh auth status
+
+# Set gh's reserved GH_REPO so subsequent gh calls (entrypoint's own
+# and the user's interactive ones) target the project repo by default.
+export GH_REPO="${GITHUB_OWNER}/${GITHUB_REPO}"
+
 success "GitHub authentication initialized."
 
 # ----------------------------------------------------------------------
@@ -545,9 +558,9 @@ success "Author: ${GIT_AUTHOR_NAME} <${GIT_AUTHOR_EMAIL}>."
 # ----------------------------------------------------------------------
 # Clone the project repository
 # ----------------------------------------------------------------------
-section "Cloning ${GH_OWNER}/${GH_REPO} into /workspace"
+section "Cloning ${GH_REPO} into /workspace"
 
-git clone "https://github.com/${GH_OWNER}/${GH_REPO}.git" /workspace
+git clone "https://github.com/${GH_REPO}.git" /workspace
 cd /workspace
 success "Repository cloned."
 
@@ -571,13 +584,13 @@ resolve_working_branch() {
         success "No ISSUE_ID; staying on main."
     else
 
-        if ! gh issue view "${ISSUE_ID}" --repo "${GH_OWNER}/${GH_REPO}" --json number >/dev/null 2>&1; then
-            die "issue #${ISSUE_ID} not found in ${GH_OWNER}/${GH_REPO}."
+        if ! gh issue view "${ISSUE_ID}" --json number >/dev/null 2>&1; then
+            die "issue #${ISSUE_ID} not found in ${GH_REPO}."
         fi
 
         local query_result="$(gh api graphql \
-            -F owner="${GH_OWNER}" \
-            -F repo="${GH_REPO}" \
+            -F owner="${GITHUB_OWNER}" \
+            -F repo="${GITHUB_REPO}" \
             -F number="${ISSUE_ID}" \
             -f query='
                 query($owner: String!, $repo: String!, $number: Int!) {
@@ -592,7 +605,7 @@ resolve_working_branch() {
 
         # Issue not found -> .data.repository.issue is null
         if [[ "$(echo "${query_result}" | jq '.data.repository.issue')" == "null" ]]; then
-            die "issue #${ISSUE_ID} not returned by GraphQL API in ${GH_OWNER}/${GH_REPO}."
+            die "issue #${ISSUE_ID} not returned by GraphQL API in ${GH_REPO}."
         fi
 
         local linked_branches="$(echo "${query_result}" | jq -r '.data.repository.issue.linkedBranches.nodes | map(.ref.name)')"
@@ -658,7 +671,7 @@ success "Project dependencies installed."
 section "Bootstrap complete"
 
 if [[ -n "${ISSUE_ID:-}" ]]; then
-    ISSUE_TITLE="$(gh issue view "${ISSUE_ID}" --repo "${GH_OWNER}/${GH_REPO}" --json title --jq .title 2>/dev/null || echo '(unable to fetch)')"
+    ISSUE_TITLE="$(gh issue view "${ISSUE_ID}" --json title --jq .title 2>/dev/null || echo '(unable to fetch)')"
     echo "Issue: #${ISSUE_ID} — ${ISSUE_TITLE}."
 fi
 echo "Branch: $(git rev-parse --abbrev-ref HEAD)"

--- a/docs/CLAUDE-DEV-ENVIRONMENT.md
+++ b/docs/CLAUDE-DEV-ENVIRONMENT.md
@@ -151,7 +151,7 @@ Recognized. The container must hold credentials or credential material to functi
 
 * GitHub Token is single-repository and has no administration permissions.
 * Claude OAuth token is revocable.
-* `GH_TOKEN` is used for `gh auth login` and then removed from the process environment before handing off to Claude Code, where practical.
+* The GitHub token is used for `gh auth login` and then removed from the process environment before handing off to Claude Code, where practical.
 * Exfiltration routes are constrained by Envoy's allow-list.
 * Tokens are never stored in plaintext on host disk.
 
@@ -281,7 +281,7 @@ The launcher retrieves both tokens at runtime:
 
 ```bash
 CLAUDE_CODE_OAUTH_TOKEN=$(secret-tool lookup service claude-dev account claude-oauth)
-GH_TOKEN=$(secret-tool lookup service claude-dev account github-token)
+GITHUB_TOKEN_=$(secret-tool lookup service claude-dev account github-token)
 ```
 
 If either lookup returns empty, the launcher fails fast with a bootstrap-procedure pointer.
@@ -617,9 +617,9 @@ The launcher reads `scripts/claude-dev.env`.
 Required target variables:
 
 ```bash
-#Github repo 
-GH_OWNER=
-GH_REPO=
+#Github repo
+GITHUB_OWNER=
+GITHUB_REPO=
 
 # Claude dev container image configuration
 CLAUDE_DEV_IMAGE=
@@ -717,11 +717,11 @@ Container-side script. It validates the runtime contract, starts the local proxy
 
 8. Configure GitHub authentication using `gh auth login --with-token`.
 
-9. Remove `GH_TOKEN` from the process environment after GitHub authentication is initialized, where practical.
+9. Remove `GITHUB_TOKEN_` from the process environment after GitHub authentication is initialized. Set `GH_REPO=${GITHUB_OWNER}/${GITHUB_REPO}` so subsequent gh calls have a repo default.
 
 10. Configure git identity.
 
-11. Clone `https://github.com/${GH_OWNER}/${GH_REPO}.git` into `/workspace`.
+11. Clone `https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}.git` into `/workspace`.
 
 12. Resolve working branch:
 

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -201,9 +201,9 @@ Policy clarification:
   * no unexpected writable non-tmpfs mounts
 * Starts `socat` proxy bridge before any GitHub/git/uv network work.
 * GitHub auth:
-  * stores `GH_TOKEN` in temp variable
-  * unsets `GH_TOKEN`
-  * pipes token to `gh auth login --with-token --hostname github.com`
+  * pipes `GITHUB_TOKEN_` (the launcher → container contract; trailing underscore avoids gh's reserved `GH_TOKEN`/`GITHUB_TOKEN` so no pre-unset dance) to `gh auth login --with-token --hostname github.com`
+  * unsets `GITHUB_TOKEN_` after auth
+  * exports `GH_REPO=${GITHUB_OWNER}/${GITHUB_REPO}` so subsequent gh calls (entrypoint and interactive) default to the project repo
   * runs `gh auth setup-git`
   * runs `gh auth status`
 * Configures git author using GitHub API user id/login.
@@ -263,8 +263,8 @@ Policy clarification:
 
 Host/project launcher variables include at least:
 
-* `GH_OWNER`
-* `GH_REPO`
+* `GITHUB_OWNER`
+* `GITHUB_REPO`
 * `ENVOY_IMAGE`
 * `ENVOY_ADMIN_HOST_PORT`
 * `ENVOY_ADMIN_CONTAINER_PORT`

--- a/scripts/claude-dev.env
+++ b/scripts/claude-dev.env
@@ -1,9 +1,9 @@
 # Per-project launcher configuration (sourced by claude-dev.sh).
 # Update via chore Issue when project identity or image registry changes.
 
-#Github repo 
-GH_OWNER=nightjarrr
-GH_REPO=molim
+#Github repo
+GITHUB_OWNER=nightjarrr
+GITHUB_REPO=molim
 
 # Claude dev container image configuration
 CLAUDE_DEV_IMAGE=molim-devenv

--- a/scripts/claude-dev.sh
+++ b/scripts/claude-dev.sh
@@ -154,8 +154,8 @@ fi
 # shellcheck disable=SC1090
 source "$ENV_FILE"
 
-require_var GH_OWNER
-require_var GH_REPO
+require_var GITHUB_OWNER
+require_var GITHUB_REPO
 
 require_var CLAUDE_DEV_IMAGE
 require_var CLAUDE_DEV_USER
@@ -172,7 +172,7 @@ require_var ENVOY_ADMIN_CONTAINER_PORT
 require_var ENVOY_ADMIN_ADDRESS
 require_var ENVOY_SOCKET_CONTAINER_PATH
 
-export GH_OWNER GH_REPO
+export GITHUB_OWNER GITHUB_REPO
 
 # ----------------------------------------------------------------------
 # If not already inside tmux, re-enter this launcher inside a tmux session.
@@ -225,9 +225,9 @@ if [[ -z "${TMUX:-}" ]]; then
 
     SUFFIX="$(openssl rand -hex 2)"
     if [[ -n "$ISSUE_ID" ]]; then
-        TMUX_SESSION="${GH_OWNER}-${GH_REPO}-${ISSUE_ID}-${SUFFIX}"
+        TMUX_SESSION="${GITHUB_OWNER}-${GITHUB_REPO}-${ISSUE_ID}-${SUFFIX}"
     else
-        TMUX_SESSION="${GH_OWNER}-${GH_REPO}-${SUFFIX}"
+        TMUX_SESSION="${GITHUB_OWNER}-${GITHUB_REPO}-${SUFFIX}"
     fi
     export TMUX_SESSION
     echo "tmux session: ${TMUX_SESSION}"
@@ -250,8 +250,8 @@ keyring_lookup() {
 }
 
 CLAUDE_CODE_OAUTH_TOKEN="$(keyring_lookup claude-oauth)"
-GH_TOKEN="$(keyring_lookup github-token)"
-export CLAUDE_CODE_OAUTH_TOKEN GH_TOKEN
+GITHUB_TOKEN_="$(keyring_lookup github-token)"
+export CLAUDE_CODE_OAUTH_TOKEN GITHUB_TOKEN_
 
 # ----------------------------------------------------------------------
 # Detect host timezone
@@ -388,8 +388,8 @@ wait_for_envoy() {
 # ----------------------------------------------------------------------
 DOCKER_ARGS=(
     run --rm -it
-    -e GH_OWNER -e GH_REPO
-    -e CLAUDE_CODE_OAUTH_TOKEN -e GH_TOKEN
+    -e GITHUB_OWNER -e GITHUB_REPO
+    -e CLAUDE_CODE_OAUTH_TOKEN -e GITHUB_TOKEN_
     -e TZ
 
     # Capability and privilege restrictions


### PR DESCRIPTION
## What this PR does

The launcher → container contract now uses logical names GITHUB_OWNER / GITHUB_REPO and a trailing-underscore GITHUB_TOKEN_ for the token. The old GH_OWNER, GH_REPO, GH_TOKEN names collided with gh's reserved env vars (gh expects GH_REPO=OWNER/REPO and treats GH_TOKEN/GITHUB_TOKEN as auth credentials), which broke ad-hoc gh invocations and forced an awkward unset-and-temp-var dance during gh auth login.

The entrypoint now constructs and exports GH_REPO=OWNER/REPO once after auth, so all downstream gh calls (entrypoint's own and the user's interactive ones) target the project repo by default. Explicit --repo flags removed from entrypoint gh calls; auth flow simplified to a single pipe + unset.

Closes nightjarrr/adda-dev-runtime#17 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / configuration

## Checklist

- [x] All tests pass (`uv run pytest`)
- [ ] New functionality is covered by tests
- [ ] Code is formatted and linted (`uv run pre-commit run --all-files`)
- [x] PR title is a clear, human-readable summary of the change
