### PR TITLE
Install Micro 2.0.15 as default TUI editor in Claude dev container

### DIFF
--- a/.devcontainer/claude-dev/Dockerfile
+++ b/.devcontainer/claude-dev/Dockerfile
@@ -84,6 +84,20 @@ RUN curl -fsSL "https://github.com/cli/cli/releases/download/v2.91.0/gh_2.91.0_l
     && rm -rf /var/lib/apt/lists/*
 
 # ----------------------------------------------------------------------
+# Micro — TUI text editor, installed from official GitHub release.
+# Static binary; no runtime dependencies.
+# ----------------------------------------------------------------------
+ENV MICRO_VERSION=2.0.15 \
+    EDITOR=micro \
+    VISUAL=micro
+RUN curl -fsSL "https://github.com/micro-editor/micro/releases/download/v${MICRO_VERSION}/micro-${MICRO_VERSION}-linux64-static.tar.gz" \
+        -o /tmp/micro.tar.gz \
+    && tar -xzf /tmp/micro.tar.gz -C /tmp \
+    && mv /tmp/micro-${MICRO_VERSION}/micro /usr/local/bin/micro \
+    && rm /tmp/micro.tar.gz \
+    && rm -rf /tmp/micro-${MICRO_VERSION}
+
+# ----------------------------------------------------------------------
 # Claude Code — official npm package, version-pinned
 # ----------------------------------------------------------------------
 ENV CLAUDE_CODE_VERSION=2.1.112

--- a/docs/CLAUDE-DEV-ENVIRONMENT.md
+++ b/docs/CLAUDE-DEV-ENVIRONMENT.md
@@ -216,6 +216,8 @@ Multiple features may run concurrently. Each invocation gets its own Claude cont
 
 Claude Code is a TUI. The container provides a real PTY (`docker run -it`), `TERM=xterm-256color` or compatible behavior, and a UTF-8 locale.
 
+Micro is installed as the default TUI editor (`EDITOR=micro`, `VISUAL=micro`). It is available for interactive file editing and is the fallback editor for CLI tools that open `$EDITOR` (e.g. `git commit`, `gh pr create`).
+
 ### Survivability
 
 The launcher creates a named host `tmux` session and re-enters itself inside that session. This keeps the launcher, Envoy sidecar lifecycle, and `docker run` under tmux control. If the terminal emulator crashes or closes, the tmux server keeps the session alive. Reattach using the printed tmux session name.

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -85,6 +85,14 @@ Audience: AI agent or maintainer continuing implementation.
 
 ---
 
+## Installed developer tooling
+
+* Micro 2.0.15 — TUI text editor, static binary at `/usr/local/bin/micro`.
+* `EDITOR=micro` and `VISUAL=micro` set via Dockerfile `ENV`; inherited by all container processes including non-interactive subshells.
+* No Micro config is included; defaults are used. `~/.config/micro/` is not pre-populated (it would live on the ephemeral `/home/node` tmpfs).
+
+---
+
 ## Claude container current `docker run` shape
 
 Current important flags:


### PR DESCRIPTION
## Summary

- Installs Micro 2.0.15 (static binary from official GitHub release) into the BASE section of the Claude dev container image
- Sets `EDITOR=micro` and `VISUAL=micro` as Dockerfile `ENV` vars, co-located with `MICRO_VERSION`, so all processes inherit the editor default including non-interactive Claude subshells
- Updates `docs/CLAUDE-DEV-ENVIRONMENT.md` (TUI requirements section) and `docs/CURRENT-STATE.md` (new installed tooling section)

## Test plan

- [ ] Build image: `docker build -f .devcontainer/claude-dev/Dockerfile -t molim-devenv .`
- [ ] Start session: `./scripts/claude-dev.sh`
- [ ] Inside session: `micro --version` — binary present and runnable
- [ ] Inside session: `env | grep -E 'EDITOR|VISUAL'` — both vars set to `micro`
- [ ] Inside session: `micro /etc/hostname` — editor launches with correct defaults; exit with Ctrl+Q

Closes nightjarrr/adda-dev-runtime#18

🤖 Generated with [Claude Code](https://claude.com/claude-code)