### PR TITLE
Install delta 0.19.2 as syntax-highlighting git diff pager

### DIFF
--- a/.devcontainer/claude-dev/Dockerfile
+++ b/.devcontainer/claude-dev/Dockerfile
@@ -98,6 +98,22 @@ RUN curl -fsSL "https://github.com/micro-editor/micro/releases/download/v${MICRO
     && rm -rf /tmp/micro-${MICRO_VERSION}
 
 # ----------------------------------------------------------------------
+# delta — syntax-highlighting diff pager for git, from official GitHub release.
+# Static (musl) binary; no runtime dependencies.
+# ----------------------------------------------------------------------
+ENV DELTA_VERSION=0.19.2
+RUN curl -fsSL "https://github.com/dandavison/delta/releases/download/${DELTA_VERSION}/delta-${DELTA_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+        -o /tmp/delta.tar.gz \
+    && tar -xzf /tmp/delta.tar.gz -C /tmp \
+    && mv /tmp/delta-${DELTA_VERSION}-x86_64-unknown-linux-musl/delta /usr/local/bin/delta \
+    && rm /tmp/delta.tar.gz \
+    && rm -rf /tmp/delta-${DELTA_VERSION}-x86_64-unknown-linux-musl \
+    && git config --system core.pager delta \
+    && git config --system interactive.diffFilter "delta --color-only" \
+    && git config --system delta.line-numbers true \
+    && git config --system delta.navigate true
+
+# ----------------------------------------------------------------------
 # Claude Code — official npm package, version-pinned
 # ----------------------------------------------------------------------
 ENV CLAUDE_CODE_VERSION=2.1.112

--- a/docs/CLAUDE-DEV-ENVIRONMENT.md
+++ b/docs/CLAUDE-DEV-ENVIRONMENT.md
@@ -218,6 +218,8 @@ Claude Code is a TUI. The container provides a real PTY (`docker run -it`), `TER
 
 Micro is installed as the default TUI editor (`EDITOR=micro`, `VISUAL=micro`). It is available for interactive file editing and is the fallback editor for CLI tools that open `$EDITOR` (e.g. `git commit`, `gh pr create`).
 
+delta is installed as the git diff pager. All `git diff`, `git show`, `git log -p`, and `git add -p` output is automatically routed through delta for syntax highlighting, line numbers, and hunk navigation (n/N).
+
 ### Survivability
 
 The launcher creates a named host `tmux` session and re-enters itself inside that session. This keeps the launcher, Envoy sidecar lifecycle, and `docker run` under tmux control. If the terminal emulator crashes or closes, the tmux server keeps the session alive. Reattach using the printed tmux session name.

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -88,6 +88,7 @@ Audience: AI agent or maintainer continuing implementation.
 ## Installed developer tooling
 
 * Micro 2.0.15 — TUI text editor, static binary at `/usr/local/bin/micro`.
+* delta 0.19.2 — syntax-highlighting git diff pager, static binary at `/usr/local/bin/delta`. Wired in via `/etc/gitconfig` (system-level): `core.pager`, `interactive.diffFilter`, `delta.line-numbers = true`, `delta.navigate = true`.
 * `EDITOR=micro` and `VISUAL=micro` set via Dockerfile `ENV`; inherited by all container processes including non-interactive subshells.
 * No Micro config is included; defaults are used. `~/.config/micro/` is not pre-populated (it would live on the ephemeral `/home/node` tmpfs).
 


### PR DESCRIPTION
## Summary

- Installs delta 0.19.2 (static musl binary from official GitHub release) into the BASE section of the Claude dev container image
- Wires delta in as the git pager via `git config --system` (writes to `/etc/gitconfig`, part of the read-only image root — not affected by tmpfs mounts at runtime)
- Enables `line-numbers = true` and `navigate = true` as sensible defaults; all other delta settings left at delta's own defaults
- Updates `docs/CLAUDE-DEV-ENVIRONMENT.md` (TUI requirements section) and `docs/CURRENT-STATE.md` (installed tooling section)

## Test plan

- [ ] Build image: `docker build -f .devcontainer/claude-dev/Dockerfile -t molim-devenv .`
- [ ] Start session: `./scripts/claude-dev.sh`
- [ ] Inside session: `delta --version` — binary present and runnable
- [ ] Inside session: `git config --system --list | grep -E 'pager|difffilter|delta'` — all four config entries set
- [ ] Inside session: `git log -p -1` — diff output routed through delta with syntax highlighting and line numbers
- [ ] Press `n` / `N` to confirm hunk navigation works; `q` to exit

Closes nightjarrr/adda-dev-runtime#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)