### PR TITLE
Add tool permission defaults to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,34 @@
 {
   "enabledPlugins": {
     "skill-creator@claude-plugins-official": true
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git *)",
+      "Bash(gh issue *)",
+      "Bash(gh pr create)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list)",
+      "Bash(gh pr diff)",
+      "Bash(gh pr status)",
+      "Bash(gh pr checks)",
+      "Bash(uv run pytest *)",
+      "Bash(uv run ruff *)",
+      "Bash(uv run pre-commit *)",
+      "Bash(uv run molim *)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:code.claude.com)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:docs.astral.sh)",
+      "WebFetch(domain:docs.python.org)"
+    ],
+    "deny": [
+      "Bash(gh pr merge)",
+      "Bash(git push --force)",
+      "Bash(git push --force-with-lease)",
+      "Bash(gh secret *)",
+      "Bash(gh auth *)",
+      "Bash(gh repo delete *)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `permissions.allow` for routine dev-loop operations (git, gh issue, gh pr read/create, uv run, WebFetch to trusted docs) so they run without prompting
- Adds `permissions.deny` hard-blocking irreversible/high-blast-radius operations: `gh pr merge`, force-push variants, `gh secret *`, `gh auth *`, `gh repo delete *`
- Everything else (e.g. `gh pr close`, `gh pr edit`) falls through to the normal per-use approval prompt

Closes #36

## Test plan

- [x] `git status` runs without a permission prompt
- [x] `gh pr merge` is hard-blocked (no prompt, just denied)
- [x] `gh pr close` triggers an approval prompt (neither allowed nor denied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)