### PR TITLE
Replace separate envoy-logs session with 3-window tmux session

### DIFF
--- a/docs/CLAUDE-DEV-ENVIRONMENT.md
+++ b/docs/CLAUDE-DEV-ENVIRONMENT.md
@@ -224,7 +224,7 @@ delta is installed as the git diff pager. All `git diff`, `git show`, `git log -
 
 The launcher creates a named host `tmux` session and re-enters itself inside that session. This keeps the launcher, Envoy sidecar lifecycle, and `docker run` under tmux control. If the terminal emulator crashes or closes, the tmux server keeps the session alive. Reattach using the printed tmux session name.
 
-The launcher may also start a separate detached tmux session for easy Envoy log monitoring, named after the primary session with an `-envoy-logs` suffix.
+The launcher also opens a `claude-dev shell` window (interactive bash in the Claude container) and a `claude-dev envoy logs` window in the same session.
 
 ---
 
@@ -656,8 +656,8 @@ ENVOY_SOCKET_CONTAINER_PATH=/run/claude-dev-proxy/proxy.sock
 8. Create a private per-run runtime directory under `${XDG_RUNTIME_DIR:-/tmp}`.
 9. Render Envoy config from `.devcontainer/envoy/envoy.yaml.template` into the runtime directory.
 10. Start Envoy sidecar container with hardened flags.
-11. Start optional detached Envoy logs tmux session.
-12. Wait for the Envoy Unix socket.
+11. Wait for the Envoy Unix socket.
+12. Create `claude-dev shell` and `claude-dev envoy logs` windows in the primary tmux session.
 13. Assemble and run the Claude dev container with:
 
     * `--rm -it`

--- a/docs/CLAUDE-DEV-ENVIRONMENT.md
+++ b/docs/CLAUDE-DEV-ENVIRONMENT.md
@@ -224,7 +224,7 @@ delta is installed as the git diff pager. All `git diff`, `git show`, `git log -
 
 The launcher creates a named host `tmux` session and re-enters itself inside that session. This keeps the launcher, Envoy sidecar lifecycle, and `docker run` under tmux control. If the terminal emulator crashes or closes, the tmux server keeps the session alive. Reattach using the printed tmux session name.
 
-The launcher also opens a `claude-dev shell` window (interactive bash in the Claude container) and a `claude-dev envoy logs` window in the same session.
+The launcher also opens a `claude-dev shell` window (interactive bash in the Claude container) and a `claude-dev envoy logs` window (`docker logs -f` on the Envoy sidecar) in the same session.
 
 ---
 

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -70,7 +70,7 @@ Audience: AI agent or maintainer continuing implementation.
 * Launcher seeds `~/.tmux.conf` from `scripts/claude-dev.tmux.conf` only if missing.
 * Launcher sources `~/.tmux.conf` best-effort; failures are warnings, not fatal.
 * Launcher creates a named tmux session and re-enters itself inside it.
-* `TMUX_SESSION` must be exported before re-entry; Envoy logs tmux session depends on this.
+* `TMUX_SESSION` must be exported before re-entry; tmux window setup depends on this.
 * Launcher retrieves secrets from keyring:
   * `service=claude-dev account=claude-oauth`
   * `service=claude-dev account=github-token`
@@ -79,8 +79,8 @@ Audience: AI agent or maintainer continuing implementation.
 * Launcher starts Envoy sidecar detached with `--rm`.
 * Launcher exposes Envoy admin on host loopback, currently `127.0.0.1:7001`.
 * Launcher waits for Envoy socket before starting Claude container.
-* Launcher starts optional detached tmux session running `docker logs -f ${ENVOY_CONTAINER}`.
-* Launcher starts Claude container interactively with `docker run --rm -it`.
+* Launcher creates two additional windows in the primary tmux session: `claude-dev shell` (interactive bash into Claude container) and `claude-dev envoy logs` (`docker logs -f ${ENVOY_CONTAINER}`).
+* Launcher starts Claude container interactively with `docker run --rm -it --name ${CLAUDE_CONTAINER}`.
 * Launcher cleanup stops Envoy container and removes runtime dir on exit.
 
 ---
@@ -227,11 +227,11 @@ Policy clarification:
 
 ## Tmux current behavior
 
-* Launcher creates primary tmux session for Claude dev runtime.
-* Launcher may create detached tmux session for Envoy logs:
+* Launcher creates primary tmux session with three windows:
 
-  * name: `${TMUX_SESSION}-envoy-logs`
-  * command: `docker logs -f ${ENVOY_CONTAINER}`
+  * `claude-dev primary` — Claude container (`docker run`)
+  * `claude-dev shell` — interactive `docker exec bash` into Claude container
+  * `claude-dev envoy logs` — `docker logs -f ${ENVOY_CONTAINER}`
 * `Ctrl-b d` detaches from tmux without killing underlying command.
 * Tmux seed config is copied to `~/.tmux.conf` only if missing.
 * Existing user `~/.tmux.conf` is never overwritten.

--- a/scripts/claude-dev.sh
+++ b/scripts/claude-dev.sh
@@ -233,7 +233,7 @@ if [[ -z "${TMUX:-}" ]]; then
     echo "tmux session: ${TMUX_SESSION}"
 
     TMUX_COMMAND="$(quote_command "$SCRIPT_PATH" "$@")"
-    exec tmux new-session -s "${TMUX_SESSION}" "${TMUX_COMMAND}"
+    exec tmux new-session -s "${TMUX_SESSION}" -n "claude-dev primary" "${TMUX_COMMAND}"
 fi
 
 # ----------------------------------------------------------------------
@@ -316,7 +316,6 @@ prepare_envoy() {
     chmod 600 "$ENVOY_RUNTIME_CONFIG"
 }
 
-
 start_envoy() {
     prepare_envoy
 
@@ -334,7 +333,6 @@ start_envoy() {
         -v "${RUN_DIR}:/run/claude-dev-proxy:rw" \
         "${ENVOY_IMAGE}" \
         -c /run/claude-dev-proxy/envoy.yaml
-
 }
 
 # Envoy socket on host system
@@ -370,11 +368,8 @@ setup_tmux_windows() {
         return 0
     fi
 
-    tmux rename-window -t "${TMUX_SESSION}:0" "claude-dev primary" || \
-        warning "failed to rename primary tmux window; continuing."
-
     if ! tmux new-window -t "${TMUX_SESSION}" -n "claude-dev shell" \
-        "until docker inspect -f '{{.State.Running}}' ${CLAUDE_CONTAINER} 2>/dev/null | grep -q true; do sleep 1; done; docker exec -it ${CLAUDE_CONTAINER} bash"; then
+        "c=0; until docker inspect -f '{{.State.Running}}' ${CLAUDE_CONTAINER} 2>/dev/null | grep -q true; do sleep 1; c=\$((c+1)); if [[ \$c -ge 30 ]]; then echo 'Timed out waiting for Claude container'; exit 1; fi; done; docker exec -it ${CLAUDE_CONTAINER} bash"; then
         warning "failed to create 'claude-dev shell' tmux window; to open manually: tmux new-window -t '${TMUX_SESSION}' -n 'claude-dev shell' 'docker exec -it ${CLAUDE_CONTAINER} bash'"
     fi
 

--- a/scripts/claude-dev.sh
+++ b/scripts/claude-dev.sh
@@ -277,6 +277,7 @@ RUN_BASE="${XDG_RUNTIME_DIR:-/tmp}/claude-dev"
 RUN_DIR="${RUN_BASE}/${RUN_ID}"
 
 ENVOY_CONTAINER="claude-dev-envoy-${RUN_ID}"
+CLAUDE_CONTAINER="claude-dev-claude-${RUN_ID}"
 ENVOY_RUNTIME_CONFIG="${RUN_DIR}/envoy.yaml"
 
 cleanup_envoy() {
@@ -313,29 +314,6 @@ prepare_envoy() {
     chmod 600 "$ENVOY_RUNTIME_CONFIG"
 }
 
-start_envoy_logs_tmux() {
-    if [[ -z "${TMUX_SESSION:-}" ]]; then
-        warning "TMUX_SESSION is not set; Envoy logs tmux session not started."
-        return 0
-    fi
-
-    local tmux_session="${TMUX_SESSION}-envoy-logs"
-
-    if tmux has-session -t "${tmux_session}" >/dev/null 2>&1; then
-        warning "Envoy logs tmux session already existed; not launching a second one."
-        return 0
-    fi
-
-    if tmux new-session -d \
-        -s "${tmux_session}" \
-        "docker logs -f ${ENVOY_CONTAINER}"; then
-
-        echo "Envoy logs tmux session: ${tmux_session}"
-        echo "Attach with: tmux attach -t ${tmux_session}"
-    else
-        warning "failed to start Envoy logs tmux session; continuing without it."
-    fi
-}
 
 start_envoy() {
     prepare_envoy
@@ -355,7 +333,6 @@ start_envoy() {
         "${ENVOY_IMAGE}" \
         -c /run/claude-dev-proxy/envoy.yaml
 
-    start_envoy_logs_tmux
 }
 
 # Envoy socket on host system
@@ -381,6 +358,32 @@ wait_for_envoy() {
 }
 
 # ----------------------------------------------------------------------
+# Tmux window setup
+# ----------------------------------------------------------------------
+setup_tmux_windows() {
+    if [[ -z "${TMUX_SESSION:-}" ]]; then
+        warning "TMUX_SESSION is not set; additional tmux windows not created."
+        return 0
+    fi
+
+    tmux rename-window -t "${TMUX_SESSION}:0" "claude-dev primary" || \
+        warning "failed to rename primary tmux window; continuing."
+
+    if ! tmux new-window -t "${TMUX_SESSION}" -n "claude-dev shell" \
+        "until docker inspect -f '{{.State.Running}}' ${CLAUDE_CONTAINER} 2>/dev/null | grep -q true; do sleep 1; done; docker exec -it ${CLAUDE_CONTAINER} bash"; then
+        warning "failed to create 'claude-dev shell' tmux window; to open manually: tmux new-window -t '${TMUX_SESSION}' -n 'claude-dev shell' 'docker exec -it ${CLAUDE_CONTAINER} bash'"
+    fi
+
+    if ! tmux new-window -t "${TMUX_SESSION}" -n "claude-dev envoy logs" \
+        "docker logs -f ${ENVOY_CONTAINER}"; then
+        warning "failed to create 'claude-dev envoy logs' tmux window; to open manually: tmux new-window -t '${TMUX_SESSION}' -n 'claude-dev envoy logs' 'docker logs -f ${ENVOY_CONTAINER}'"
+    fi
+
+    tmux select-window -t "${TMUX_SESSION}:claude-dev primary" || \
+        warning "failed to select primary tmux window; continuing."
+}
+
+# ----------------------------------------------------------------------
 # Build Claude container docker run argument list
 #
 # Intentionally unchanged for this draft. We are only validating that the
@@ -388,6 +391,7 @@ wait_for_envoy() {
 # ----------------------------------------------------------------------
 DOCKER_ARGS=(
     run --rm -it
+    --name "${CLAUDE_CONTAINER}"
     -e GITHUB_OWNER -e GITHUB_REPO
     -e CLAUDE_CODE_OAUTH_TOKEN -e GITHUB_TOKEN_
     -e TZ
@@ -432,6 +436,7 @@ fi
 # ----------------------------------------------------------------------
 start_envoy
 wait_for_envoy
+setup_tmux_windows
 
 echo "Starting Claude dev container..."
 docker "${DOCKER_ARGS[@]}"

--- a/scripts/claude-dev.sh
+++ b/scripts/claude-dev.sh
@@ -270,14 +270,16 @@ TZ="$(detect_host_tz)"
 export TZ
 
 # ----------------------------------------------------------------------
-# Envoy sidecar runtime setup
+# Runtime initialization
 # ----------------------------------------------------------------------
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$(openssl rand -hex 8)"
 RUN_BASE="${XDG_RUNTIME_DIR:-/tmp}/claude-dev"
 RUN_DIR="${RUN_BASE}/${RUN_ID}"
 
+# ----------------------------------------------------------------------
+# Envoy sidecar runtime setup
+# ----------------------------------------------------------------------
 ENVOY_CONTAINER="claude-dev-envoy-${RUN_ID}"
-CLAUDE_CONTAINER="claude-dev-claude-${RUN_ID}"
 ENVOY_RUNTIME_CONFIG="${RUN_DIR}/envoy.yaml"
 
 cleanup_envoy() {
@@ -360,6 +362,8 @@ wait_for_envoy() {
 # ----------------------------------------------------------------------
 # Tmux window setup
 # ----------------------------------------------------------------------
+CLAUDE_CONTAINER="claude-dev-claude-${RUN_ID}"
+
 setup_tmux_windows() {
     if [[ -z "${TMUX_SESSION:-}" ]]; then
         warning "TMUX_SESSION is not set; additional tmux windows not created."

--- a/scripts/claude-dev.tmux.conf
+++ b/scripts/claude-dev.tmux.conf
@@ -5,6 +5,9 @@
 # when ~/.tmux.conf does not already exist.
 # Existing user configuration is never overwritten.
 
+# Start window numbering at 1.
+set-option -g base-index 1
+
 # Large scrollback for agent transcripts, bootstrap logs, diffs, tests.
 set-option -gq history-limit 300000
 


### PR DESCRIPTION
## Summary

- Replaces the separate detached `${TMUX_SESSION}-envoy-logs` tmux session with three named windows in the primary session: `claude-dev primary`, `claude-dev shell`, and `claude-dev envoy logs`
- Assigns an explicit `--name` to the Claude container so the shell window can `docker exec` into it by name
- Adds `setup_tmux_windows()` in a dedicated script section (after Envoy, before Docker args); removes `start_envoy_logs_tmux()` entirely
- Updates `docs/CURRENT-STATE.md` and `docs/CLAUDE-DEV-ENVIRONMENT.md` to reflect the new 3-window model

## Test plan

- [x] Run `claude-dev.sh` and confirm three windows appear: `claude-dev primary`, `claude-dev shell`, `claude-dev envoy logs`
- [x] Confirm session lands on `claude-dev primary` with Claude running
- [x] Switch to `claude-dev shell` (`Ctrl-b 1`); confirm bash prompt inside Claude container appears once container is up
- [x] Switch to `claude-dev envoy logs` (`Ctrl-b 2`); confirm Envoy log output streams from session start
- [ ] Exit Claude container; confirm cleanup (Envoy stopped, runtime dir removed)
- [x] Confirm no separate `-envoy-logs` tmux session exists (`tmux ls`)

Closes nightjarrr/adda-dev-runtime#21

🤖 Generated with [Claude Code](https://claude.com/claude-code)