### PR TITLE
Fix wildcard specifiers in project permission rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,12 +6,13 @@
     "allow": [
       "Bash(git *)",
       "Bash(gh issue *)",
-      "Bash(gh pr create)",
+      "Bash(gh pr create *)",
       "Bash(gh pr view *)",
-      "Bash(gh pr list)",
-      "Bash(gh pr diff)",
-      "Bash(gh pr status)",
-      "Bash(gh pr checks)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr diff *)",
+      "Bash(gh pr status *)",
+      "Bash(gh pr checks *)",
+      "Bash(echo *)",
       "Bash(uv run pytest *)",
       "Bash(uv run ruff *)",
       "Bash(uv run pre-commit *)",
@@ -23,9 +24,11 @@
       "WebFetch(domain:docs.python.org)"
     ],
     "deny": [
-      "Bash(gh pr merge)",
-      "Bash(git push --force)",
-      "Bash(git push --force-with-lease)",
+      "Bash(gh pr merge *)",
+      "Bash(git push --force *)",
+      "Bash(git push * --force *)",
+      "Bash(git push --force-with-lease *)",
+      "Bash(git push * --force-with-lease *)",
       "Bash(gh secret *)",
       "Bash(gh auth *)",
       "Bash(gh repo delete *)"


### PR DESCRIPTION
Closes #57

## Changes

**Allow list** — added missing `*` wildcards to `gh pr` subcommands so invocations with flags don't prompt unnecessarily. Added `Bash(echo *)` to suppress prompts when inspecting `$ISSUE_ID`.

**Deny list** — expanded force-push and merge entries to cover all flag positions:
- `git push --force *` / `git push * --force *` (flag-first and flag-last/middle)
- `git push --force-with-lease *` / `git push * --force-with-lease *`
- `gh pr merge *` (covers bare and with arguments)

Pattern rationale documented in [the permissions docs](https://code.claude.com/docs/en/permissions#wildcard-patterns): trailing ` *` matches end-of-string, so `--force *` covers the bare case too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)