### PR TITLE
Use printenv for ISSUE_ID lookup to avoid confirmation prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,7 +12,7 @@
       "Bash(gh pr diff *)",
       "Bash(gh pr status *)",
       "Bash(gh pr checks *)",
-      "Bash(echo *)",
+      "Bash(printenv *)",
       "Bash(uv run pytest *)",
       "Bash(uv run ruff *)",
       "Bash(uv run pre-commit *)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Tests are required for new Python code. Each bugfix must be covered by a set of 
 
 ## Issues
 
-All work is tracked in GitHub issues. As a first step of every development you need to understand which issue number is tracking it. Check if environment variable $ISSUE_ID holds the value, then confirm with the user. The user can give you a different number.
+All work is tracked in GitHub issues. As a first step of every development you need to understand which issue number is tracking it. Run `printenv ISSUE_ID` to check the environment variable, then confirm with the user. The user can give you a different number.
 
 If there is no issue yet, suggest that the user creates it using /new-issue skill.
 


### PR DESCRIPTION
## Summary
- Replace `Bash(echo *)` allowlist entry with `Bash(printenv *)` in `.claude/settings.json`
- Update `CLAUDE.md` to instruct the agent to use `printenv ISSUE_ID` instead of `echo $ISSUE_ID`

## Test plan
- [ ] Start a new session — the `printenv ISSUE_ID` call should execute without a confirmation prompt

Closes nightjarrr/adda-dev-runtime#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)