### PR TITLE
chore: set delta diff theme and color scheme in dev container

### DIFF
--- a/.devcontainer/claude-dev/Dockerfile
+++ b/.devcontainer/claude-dev/Dockerfile
@@ -34,7 +34,8 @@ FROM node:24.15.0-bookworm-slim
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    TERM=xterm-256color
+    TERM=xterm-256color \
+    COLORTERM=truecolor
 
 # ----------------------------------------------------------------------
 # System packages required by the Claude Code dev environment

--- a/.devcontainer/claude-dev/Dockerfile
+++ b/.devcontainer/claude-dev/Dockerfile
@@ -111,7 +111,13 @@ RUN curl -fsSL "https://github.com/dandavison/delta/releases/download/${DELTA_VE
     && git config --system core.pager delta \
     && git config --system interactive.diffFilter "delta --color-only" \
     && git config --system delta.line-numbers true \
-    && git config --system delta.navigate true
+    && git config --system delta.navigate true \
+    && mkdir -p /etc/delta \
+    && curl -fsSL "https://raw.githubusercontent.com/dandavison/delta/${DELTA_VERSION}/themes.gitconfig" \
+        -o /etc/delta/themes.gitconfig \
+    && git config --system include.path /etc/delta/themes.gitconfig \
+    && git config --system delta.features mellow-barbet \
+    && git config --system delta.side-by-side false
 
 # ----------------------------------------------------------------------
 # Claude Code — official npm package, version-pinned


### PR DESCRIPTION
## Summary

- Downloads `themes.gitconfig` from the pinned upstream delta release at image build time and stores it at `/etc/delta/themes.gitconfig`
- Activates the `mellow-barbet` theme via system-level git config; sets `side-by-side = false` to override the theme default
- Adds `COLORTERM=truecolor` to the container `ENV` alongside `TERM=xterm-256color` — required for mellow-barbet's tight dark-gray palette to render correctly in 24-bit color

Having the full `themes.gitconfig` baked into the image means switching themes later is a one-liner config change.

Closes nightjarrr/adda-dev-runtime#26
Closes nightjarrr/adda-dev-runtime#33

## Test plan

- [x] Build the dev container image
- [x] `docker run --rm <image> cat /etc/gitconfig` — verify theme config is present
- [x] `docker run --rm <image> head -5 /etc/delta/themes.gitconfig` — verify themes file was downloaded
- [x] `git diff HEAD~1 | delta` inside the container — verify mellow-barbet renders with true color

🤖 Generated with [Claude Code](https://claude.com/claude-code)