### PR TITLE
Fixed OutputFilePathStrategy.get_output_path base class definition missing self parameter.

### DIFF
--- a/src/molim/processing.py
+++ b/src/molim/processing.py
@@ -4,7 +4,7 @@ from . import check, show, stats
 
 
 class OutputFilePathStrategy:
-    def get_output_path(input_path: pathlib.Path):
+    def get_output_path(self, input_path: pathlib.Path):
         raise NotImplementedError()
 
 


### PR DESCRIPTION
## What this PR does

Fixed OutputFilePathStrategy.get_output_path base class definition missing self parameter.
Closes #84 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI / configuration

## Checklist

- [x] All tests pass (`uv run pytest`)
- [ ] New functionality is covered by tests
- [x] Code is formatted and linted (`uv run pre-commit run --all-files`)
- [x] PR title is a clear, human-readable summary of the change
