### PR TITLE
Added gh release list *, gh release view * to Claude allow-list

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,8 @@
       "Bash(gh pr diff *)",
       "Bash(gh pr status *)",
       "Bash(gh pr checks *)",
+      "Bash(gh release list *)",
+      "Bash(gh release view *)",
       "Bash(printenv *)",
       "Bash(uv run pytest *)",
       "Bash(uv run ruff *)",


### PR DESCRIPTION
## What this PR does

Added gh release list *, gh release view * to Claude allow-list
Closes nightjarrr/adda-dev-runtime#29 

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI / configuration

## Checklist

- [x] All tests pass (`uv run pytest`)
- [ ] New functionality is covered by tests
- [ ] Code is formatted and linted (`uv run pre-commit run --all-files`)
- [x] PR title is a clear, human-readable summary of the change
