### PR TITLE
Add architecture.md and refine documentation boundary

### DIFF
--- a/docs/AGENTIC-SDLC.md
+++ b/docs/AGENTIC-SDLC.md
@@ -84,8 +84,12 @@ When PM delegates a step to AA or Coder, it constructs a self-contained task des
 - The originating Issue ID, title, type, and current phase.
 - The relevant Issue body content and any pertinent comments.
 - Paths to all prior artifacts produced for this Issue (spec, tech-design, impl-plan, as applicable).
-- Paths to relevant project-wide context documents (`architecture.md`,
-  `conventions.md`).
+- Paths to relevant project-wide context documents, scoped to the subagent's
+  audience: `architecture.md` and `conventions.md` for AA; `conventions.md` only
+  for Coder. Coder is not given `architecture.md` — any architectural context
+  Coder needs is carried by `impl-plan.md` (see Phase 4). If the impl-plan is
+  insufficient for Coder to proceed, the recourse is escalation via PM relay,
+  not reading `architecture.md`.
 - The specific deliverable expected from this step.
 - Any constraints or decisions surfaced earlier in the workflow that bound the subagent's work.
 
@@ -470,7 +474,11 @@ On Project Owner approval, PM sets the phase label directly to `phase: impl-done
 
 **Output:** `docs/{issue-id}-{slug}/impl-plan.md`
 
-**Contents of impl-plan.md:**
+**Contents of impl-plan.md** — two sections:
+
+*Architecture context.* A filtered architectural view of the parts of the system this feature touches, synthesized from `architecture.md` (the existing system shape), `tech-design.md` (architectural decisions made for this feature, not yet reflected in `architecture.md`), and the current codebase. AA filters and distils — new design choices belong in `tech-design.md`, not here. Proportional to feature complexity: a trivial change may need a sentence or two; a cross-cutting feature may need a substantial section. This section is what allows Coder to execute without reading `architecture.md` directly.
+
+*Work breakdown.*
 - Ordered list of implementation steps.
 - For each step: files to create/modify/remove, classes/functions to add/change/remove.
 - Test coverage plan: what new tests are required.
@@ -479,7 +487,7 @@ On Project Owner approval, PM sets the phase label directly to `phase: impl-done
 | Step | Executor | Skills |
 |---|---|---|
 | Validate Issue state. | PM | Validate Issue |
-| Read `spec.md` and `tech-design.md`, relevant source files listed in `tech-design.md` | AA (delegated by PM). | — |
+| Read `spec.md`, `tech-design.md`, `architecture.md`, and relevant source files listed in `tech-design.md`. | AA (delegated by PM) | — |
 | Draft `impl-plan.md`, iterate with Project Owner. | AA (delegated by PM) | — |
 | Commit `impl-plan.md` to feature branch, push feature branch. | AA (delegated by PM) | — |
 | Update Issue body with link to `impl-plan.md` in the feature branch. | PM | — |

--- a/docs/AGENTIC-SDLC.md
+++ b/docs/AGENTIC-SDLC.md
@@ -86,10 +86,10 @@ When PM delegates a step to AA or Coder, it constructs a self-contained task des
 - Paths to all prior artifacts produced for this Issue (spec, tech-design, impl-plan, as applicable).
 - Paths to relevant project-wide context documents, scoped to the subagent's
   audience: `architecture.md` and `conventions.md` for AA; `conventions.md` only
-  for Coder. Coder is not given `architecture.md` — any architectural context
-  Coder needs is carried by `impl-plan.md` (see Phase 4). If the impl-plan is
-  insufficient for Coder to proceed, the recourse is escalation via PM relay,
-  not reading `architecture.md`.
+  for Coder. AA is responsible for carrying any architectural context Coder
+  needs into `impl-plan.md` (see Phase 4); the workflow does not depend on
+  Coder reading `architecture.md`. If the impl-plan is insufficient for Coder
+  to proceed, the recourse is escalation via PM relay.
 - The specific deliverable expected from this step.
 - Any constraints or decisions surfaced earlier in the workflow that bound the subagent's work.
 
@@ -476,7 +476,7 @@ On Project Owner approval, PM sets the phase label directly to `phase: impl-done
 
 **Contents of impl-plan.md** — two sections:
 
-**Architecture context.** A filtered architectural view of the parts of the system this feature touches, synthesized from `architecture.md` (the existing system shape), `tech-design.md` (architectural decisions made for this feature, not yet reflected in `architecture.md`), and the current codebase. For architecture context section, AA filters and distils — new design choices belong in `tech-design.md`, not here. Proportional to feature complexity: a trivial change may need a sentence or two; a cross-cutting feature may need a substantial section. This section is what allows Coder to execute having the right amount of architecture awareness without reading the full `architecture.md`.
+**Architecture context.** A filtered architectural view of the parts of the system this feature touches, synthesized from `architecture.md` (the existing system shape), `tech-design.md` (architectural decisions made for this feature, not yet reflected in `architecture.md`), and the current codebase. For architecture context section, AA filters and distils — new design choices belong in `tech-design.md`, not here. If AA finds that the impl-plan needs design that isn't yet captured in `tech-design.md`, AA escalates via PM rather than embedding new design in this section. Proportional to feature complexity: a trivial change may need a sentence or two; a cross-cutting feature may need a substantial section. This section is what allows Coder to execute having the right amount of architecture awareness without reading the full `architecture.md`.
 
 **Work breakdown.**
 - Ordered list of implementation steps.

--- a/docs/AGENTIC-SDLC.md
+++ b/docs/AGENTIC-SDLC.md
@@ -476,9 +476,9 @@ On Project Owner approval, PM sets the phase label directly to `phase: impl-done
 
 **Contents of impl-plan.md** — two sections:
 
-*Architecture context.* A filtered architectural view of the parts of the system this feature touches, synthesized from `architecture.md` (the existing system shape), `tech-design.md` (architectural decisions made for this feature, not yet reflected in `architecture.md`), and the current codebase. AA filters and distils — new design choices belong in `tech-design.md`, not here. Proportional to feature complexity: a trivial change may need a sentence or two; a cross-cutting feature may need a substantial section. This section is what allows Coder to execute without reading `architecture.md` directly.
+**Architecture context.** A filtered architectural view of the parts of the system this feature touches, synthesized from `architecture.md` (the existing system shape), `tech-design.md` (architectural decisions made for this feature, not yet reflected in `architecture.md`), and the current codebase. For architecture context section, AA filters and distils — new design choices belong in `tech-design.md`, not here. Proportional to feature complexity: a trivial change may need a sentence or two; a cross-cutting feature may need a substantial section. This section is what allows Coder to execute having the right amount of architecture awareness without reading the full `architecture.md`.
 
-*Work breakdown.*
+**Work breakdown.**
 - Ordered list of implementation steps.
 - For each step: files to create/modify/remove, classes/functions to add/change/remove.
 - Test coverage plan: what new tests are required.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,18 +10,52 @@ The execution model is a single invocation: `molim <command> FOLDER [options]`. 
 invocation selects one command, targets one folder, and processes all matching files in that
 folder according to the command's rules.
 
-[TODO]: We need some sort of architecture charter, guiding principles on which `molim` is built and which must be followed for any future work. Currently they are scattered across the document and called "design goals", or even not called out at all.
- - Composability
- - IoC / DI
- - Open/closed - behavior should be modified by using defined extensibility points, not by blanket rewrite of existing code
- - Single responsibility - each class has one defined task to handle
-That gives most of SOLID. In addition to that, must call out
- - self-contained environment
- - ... - what else?
+---
+
+## 2. Design principles
+
+These principles govern every design and implementation decision in molim. New features and
+changes must be evaluated against them. Where a principle is applied concretely in the
+codebase, the relevant section of this document provides detail.
+
+**Single Responsibility** — each class has one clearly defined responsibility. Modules own
+distinct concerns: output naming belongs in `OutputFilePathStrategy`, post-processing belongs
+in `PostProcessingStrategy`, user output belongs in `show`. Cross-cutting behaviour is
+extracted into mixins or shared modules rather than duplicated or inlined.
+
+**Open/Closed** — behaviour is extended through defined extensibility points, not by
+modifying existing code. New processing variants are added by subclassing the appropriate
+strategy ABC. New commands are registered in `cli.py` without touching the dispatch
+machinery. Existing base classes and templates are not modified to accommodate new cases.
+
+**Composability** — complex behaviour is assembled from small, single-purpose objects.
+`Command._execute()` composes a pipeline from independently replaceable strategy instances.
+The same strategy types are reused across commands; commands differ by the combination they
+assemble, not by internal branching. See §6 (Command framework) and §9 (Strategy families).
+
+**Inversion of Control / Dependency Injection** — components receive their dependencies via
+constructors. There is no DI framework and no service locator. `Command._execute()` is the
+composition root: it instantiates all strategies and processors and wires them together.
+There are no singletons or shared mutable instances. See §5 (Processing pipeline).
+
+**Self-contained environment** — after `uv sync --frozen`, the project builds, tests, and
+runs with no further setup. The only external prerequisites are the three CLI tools on PATH.
+New features must preserve this. Introducing a dependency on a new system tool or library
+requires explicit justification. See §3 (Toolchain).
+
+**Dry-run universality** — `--dry-run` is a first-class feature, not an afterthought. Every
+operation that modifies the filesystem must honour the `dry_run` flag. This is a
+non-negotiable constraint on all new `FileProcessor` and `PostProcessingStrategy`
+implementations. See §8 (Dry-run mode).
+
+**Fail fast** — invalid state is detected and reported at the earliest possible point.
+External tool availability is verified at processor instantiation, not at first use. Input
+validation is applied at every internal API boundary via the `check` module. Errors propagate
+to the top-level handler; unexpected failures are not silently swallowed.
 
 ---
 
-## 2. Toolchain and development environment
+## 3. Toolchain and development environment
 
 - **Package manager**: `uv` exclusively. No `pip`, no `poetry`, no direct venv activation or
   deactivation. All interactions go through `uv` subcommands. `uv pip` must also be avoided.
@@ -42,7 +76,7 @@ That gives most of SOLID. In addition to that, must call out
 
 ---
 
-## 3. Package layout
+## 4. Package layout
 
 Source lives under `src/molim/`. Image-specific functionality is grouped in `src/molim/images/`.
 
@@ -67,7 +101,7 @@ Source lives under `src/molim/`. Image-specific functionality is grouped in `src
 
 ---
 
-## 4. Processing pipeline
+## 5. Processing pipeline
 
 Execution nesting from CLI invocation to external tool run:
 
@@ -98,7 +132,7 @@ Strategy composition in `Command._execute()`:
 
 ---
 
-## 5. Command framework
+## 6. Command framework
 
 `Command` in `commands.py` is the abstract base class. It implements the Template Method
 pattern: `_execute()` is the fixed template that orchestrates every processing run.
@@ -142,7 +176,7 @@ delegation pattern.
 
 ---
 
-## 6. CLI composability
+## 7. CLI composability
 
 The CLI uses argparse subparsers: one per command, each with a fully isolated argument
 namespace. Adding a new command requires no changes to the dispatch machinery in `cli` module; it just needs to instantiate
@@ -174,7 +208,7 @@ shared concern and changes to them are codebase-wide.
 
 ---
 
-## 7. Dry-run mode
+## 8. Dry-run mode
 
 Dry-run is a first-class feature present on every command. `--dry-run` is defined in
 `Command._add_common_arguments()` and propagated through the entire processing pipeline.
@@ -195,7 +229,7 @@ Every new `FileProcessor` and `PostProcessingStrategy` implementation must honou
 
 ---
 
-## 8. Strategy families
+## 9. Strategy families
 
 `processing.py` defines six pluggable behaviour families. New variants are added by
 subclassing the appropriate ABC — no conditionals in base classes.
@@ -211,7 +245,7 @@ subclassing the appropriate ABC — no conditionals in base classes.
 
 ---
 
-## 9. External tool integration
+## 10. External tool integration
 
 `ShellCommandFileProcessor` in `shell.py` is the bridge between Python and external CLI
 tools. It uses the `sh` library.
@@ -240,7 +274,7 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 
 ---
 
-## 10. Configuration
+## 11. Configuration
 
 - **File location**: `~/.config/molim/config.toml` (default); overridden per invocation via
   `--config`.
@@ -257,7 +291,7 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 
 ---
 
-## 11. Tests
+## 12. Tests
 
 - **Approach**: real integration tests — `rawtherapee-cli`, `convert`, and `ffmpeg` are
   invoked for real. No mocking of external tools.
@@ -281,7 +315,7 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 
 ---
 
-## 12. Build, release, and distribution
+## 13. Build, release, and distribution
 
 - **Build system**: `hatchling` + `hatch-vcs` (`pyproject.toml`). `uv build` produces a
   wheel and source distribution in `dist/`.
@@ -298,7 +332,7 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 
 ---
 
-## 13. Continuous integration
+## 14. Continuous integration
 
 - **CI workflow** (`.github/workflows/ci.yml`): runs on every push to any branch and every
   pull request. Delegates to `base.yml`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,10 +12,10 @@ folder according to the command's rules.
 
 ---
 
-## 2. Tooling
+## 2. Toolchain and development environment
 
 - **Package manager**: `uv` exclusively. No `pip`, no `poetry`, no direct venv activation or
-  deactivation. All interactions go through `uv` subcommands.
+  deactivation. All interactions go through `uv` subcommands. `uv pip` must also be avoided. 
 - **Running**: `uv run <command>` — e.g. `uv run pytest`, `uv run ruff format .`,
   `uv run molim`. `uv run` resolves the project virtualenv automatically.
 - **Dependencies**: `uv sync --frozen` installs the locked set from `uv.lock` (committed).
@@ -23,18 +23,19 @@ folder according to the command's rules.
 - **Building**: `uv build` produces wheel and sdist in `dist/`.
 - **Python version**: managed by uv from `.python-version` / `requires-python` in
   `pyproject.toml`. No assumption about system Python.
-- **Self-contained**: after `uv sync --frozen`, the project can be built, tested, and run
-  with no further setup. The only external prerequisites are the three CLI tools on PATH
-  (`rawtherapee-cli`, `convert`, `ffmpeg`) — their installation is a documented requirement,
-  not a hidden assumption. No other system-level dependencies exist. Self-containment is a
-  design goal: new features must be designed to preserve it. Introducing a dependency on a
-  new system tool or library requires explicit justification.
+
+  The development environment is **Self-contained**: after `uv sync --frozen`, the project 
+  can be built, tested, and run with no further setup. The only external prerequisites are 
+  the three CLI tools on PATH (`rawtherapee-cli`, `convert`, `ffmpeg`) — their installation 
+  is a documented requirement, not a hidden assumption. No other system-level dependencies 
+  exist. Self-containment is a design goal: new features must be designed to preserve it. 
+  Introducing a dependency on a new system tool or library requires explicit justification.
 
 ---
 
 ## 3. Package layout
 
-Source lives under `src/molim/`. Image-specific commands are grouped in `src/molim/images/`.
+Source lives under `src/molim/`. Image-specific functionality is grouped in `src/molim/images/`.
 
 | Module | Responsibility |
 |---|---|
@@ -48,18 +49,18 @@ Source lives under `src/molim/`. Image-specific commands are grouped in `src/mol
 | `show.py` | All user-facing output via Rich; progress bars, size/time formatting, verbose gating |
 | `stats.py` | `FileStats` and `FolderStats` context managers for per-file and summary statistics |
 | `video.py` | `VideoFfmpegCommand` and `FfmpegFileProcessor` |
-| `rename.py` | `SuffixCommand` and `RenameFileProcessor` (filesystem rename, no shell) |
-| `images/__init__.py` | Shared image-domain constants (`JPEG_QUALITY`, `JPEG_PROCESSED_EXTENSION`, etc.) |
+| `rename.py` | `SuffixCommand` and `RenameFileProcessor` (filesystem rename, no shell, pure Python stdlib) |
+| `images/__init__.py` | Shared `images` package-wide constants (`JPEG_QUALITY`, `JPEG_PROCESSED_EXTENSION`, etc.) |
 | `images/imagemagick.py` | `ImageMagickMixin` and `ImageMagickFileProcessor` |
 | `images/jpegify.py` | `JpegifyCommand` — converts PNG / WebP / AVIF / HEIC to JPEG via ImageMagick |
 | `images/resize.py` | `ResizeCommand` — resizes JPEG via ImageMagick `-resize` |
-| `images/rawtherapee.py` | `RawTherapeeCommand`, `RawTherapeeHQCommand`, `RawTherapeeFileProcessor` |
+| `images/rawtherapee.py` | `RawTherapeeCommand`, `RawTherapeeHQCommand`, `RawTherapeeFileProcessor` ([TODO]: need short explanation as in other rows) |
 
 ---
 
 ## 4. Processing pipeline
 
-Execution flow from invocation to filesystem output:
+Execution nesting from CLI invocation to external tool run:
 
 ```
 molim <cmd> FOLDER              # __init__.main() → cli.run(sys.argv[1:])
@@ -84,20 +85,22 @@ Strategy composition in `Command._execute()`:
 8. Run `FolderProcessor(folder, matcher, skipper, processor).process(dry_run, show_size)`.
 9. Display `FolderStats`.
 
+[TODO]: add details on the code-level composition approach: manual dependency injection (constructor-based, no DI framework, just classess accepting their deps as __init__ params), no singleton or shared instances, Command as a composition root for processors and strategy instances (inside `_execute`). This approach to DI and composition is a design goal and should be followed.
+
 ---
 
 ## 5. Command framework
 
 `Command` in `commands.py` is the abstract base class. It implements the Template Method
 pattern: `_execute()` is the fixed template that orchestrates every processing run.
-Subclasses implement hook methods; they do not override `_execute()`.
+Subclasses implement hook methods; they do not override `_execute()`. [TODO]: refer to conventions.md for the _execute() override rules and consistently reflect it here.
 
-**Hook methods subclasses must implement:**
+**Hooks subclasses must implement:**
 
-| Method | Returns |
+| Method or property | Returns |
 |---|---|
 | `name` (property) | CLI subcommand name string |
-| `help` (property) | Help text string |
+| `help` (property) | CLI help text string |
 | `_add_arguments(parser)` | Adds command-specific argparse arguments |
 | `_get_common_arguments_defaults()` | Tuple of defaults / `None` values for the four common slots |
 | `_get_output_file_path_strategy(args)` | An `OutputFilePathStrategy` instance |
@@ -106,7 +109,7 @@ Subclasses implement hook methods; they do not override `_execute()`.
 
 `configure_parser()` calls `_add_arguments()` then `_add_common_arguments()` —
 command-specific arguments appear first in help output. `__call__(args)` delegates to
-`_execute()`; commands are callable objects registered via `parser.set_defaults(command=self)`.
+`_execute()`; commands are callable objects registered via `parser.set_defaults(command=self)` and called by `argparse`.
 
 **Registered commands** (instantiated in `cli.run()`):
 
@@ -117,24 +120,24 @@ command-specific arguments appear first in help output. `__call__(args)` delegat
 | `resize` | `ResizeCommand` | `images/resize.py` | `convert` (ImageMagick) |
 | `rawtherapee` | `RawTherapeeCommand` | `images/rawtherapee.py` | `rawtherapee-cli` |
 | `rawtherapee-hq` | `RawTherapeeHQCommand` | `images/rawtherapee.py` | `rawtherapee-cli` |
-| `suffix` | `SuffixCommand` | `rename.py` | — (filesystem only) |
+| `suffix` | `SuffixCommand` | `rename.py` | — (Python stdlib only) |
 
 **Mixin pattern**: `JpegifyCommand` and `ResizeCommand` inherit
 `(commands.Command, ImageMagickMixin)`. Because `Command` is listed first in the MRO,
 subclasses must explicitly delegate `_add_arguments` and `_get_file_processor` to
-`ImageMagickMixin`.
+`ImageMagickMixin`. [TODO]: add details what the mixin is doing. Refer to conventions.md
 
 ---
 
 ## 6. CLI composability
 
-The CLI uses argparse subparsers — one per command, each with a fully isolated argument
-namespace. Adding a new command requires no changes to the dispatch machinery: instantiate
+The CLI uses argparse subparsers: one per command, each with a fully isolated argument
+namespace. Adding a new command requires no changes to the dispatch machinery in `cli` module; it just needs to instantiate
 the class and pass it to `_create_parser()`.
 
-**Two-tier argument structure:**
+**Three-tier argument structure:**
 
-- *Always-present* — every command unconditionally: `FOLDER` (positional), `--config`,
+- *Always-present* — every command must support unconditionally: `FOLDER` (positional), `--config`,
   `--dry-run`, `--verbose`. Added by `_add_common_arguments()`; cannot be suppressed.
 - *Optional common slots* — four shared arguments each command opts into or suppresses by
   returning a default value or `None` from `_get_common_arguments_defaults()`:
@@ -154,7 +157,7 @@ not appear in their help text or namespace.
 base class and all subclasses. Adding a new optional common argument requires updating
 `_add_common_arguments()`, the `_get_common_arguments_defaults()` signature, and the return
 statement in every existing subclass. This coupling is intentional — common arguments are
-shared infrastructure and changes to them are codebase-wide.
+shared concern and changes to them are codebase-wide.
 
 ---
 
@@ -234,6 +237,10 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
   then `[global]`.
 - **Absence is valid**: if the config file does not exist, processing continues without it.
   No config file is required.
+  
+  [TODO]: Add even more specific guidance on the optional, additional nature of the configuration subsystem. No file - okay. No section in the file - okay. No entry in the section  - okay. No required entries in the config file.
+  Configuration is fully opt-in by the commands, there is nothing compulsory about it.
+  At design time, the question "should this be configurable in `config.toml`" is always good to ask, because there are no technical constraints that push towards adding configurable options.
 
 ---
 
@@ -249,12 +256,14 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 - **Static test data**: `tests/data/{module}/` — sample media files and config files needed
   by tests that require real inputs.
 - **Temporary filesystem state**: `tmp_path` (function-scoped) and `tmp_path_factory`
-  (module-scoped) pytest fixtures.
+  (module-scoped) pytest fixtures. Temp state must be always cleaned up as a teardown step - no matter if the test passes or fails.
 - **`monkeypatch`**: permitted only for infrastructure concerns where no real tool exists
-  (e.g. stubbing `importlib.metadata.version()` for version detection). Not used to
+  (e.g. stubbing `importlib.metadata.version()` for version detection). Never used to
   substitute external CLI tools.
 - **Test categories per class**: input validation, dry-run behavior, core logic.
 - **Runner**: pytest with branch coverage (`pytest-cov`); reports uploaded to Codecov in CI.
+
+[TODO]: add guidelines on the test coverage. Tests are not optional. Every new class or method requires tests. Every bug fix requires tests that validate the corrected behavior and ensure that regressions will be detected at unit test stage.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,15 @@ The execution model is a single invocation: `molim <command> FOLDER [options]`. 
 invocation selects one command, targets one folder, and processes all matching files in that
 folder according to the command's rules.
 
+[TODO]: We need some sort of architecture charter, guiding principles on which `molim` is built and which must be followed for any future work. Currently they are scattered across the document and called "design goals", or even not called out at all.
+ - Composability
+ - IoC / DI
+ - Open/closed - behavior should be modified by using defined extensibility points, not by blanket rewrite of existing code
+ - Single responsibility - each class has one defined task to handle
+That gives most of SOLID. In addition to that, must call out
+ - self-contained environment
+ - ... - what else?
+
 ---
 
 ## 2. Toolchain and development environment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -38,10 +38,12 @@ constructors. There is no DI framework and no service locator. `Command._execute
 composition root: it instantiates all strategies and processors and wires them together.
 There are no singletons or shared mutable instances. See **Processing pipeline**.
 
-**Self-contained environment** — after `uv sync --frozen`, the project builds, tests, and
-runs with no further setup. The only external prerequisites are the three CLI tools on PATH.
-New features must preserve this. Introducing a dependency on a new system tool or library
-requires explicit justification. See **Toolchain and development environment**.
+**Self-contained environment** — a cloned repository requires nothing beyond a small,
+documented set of host prerequisites. Everything else — dependencies, build, runtime — is
+provisioned reproducibly from the repository's metadata definitions, so development, CI,
+and any downstream environment behave identically. New features must preserve this.
+Introducing a dependency on a new system tool or library requires explicit justification.
+See **Toolchain and development environment**.
 
 **Dry-run universality** — `--dry-run` is a first-class feature, not an afterthought. Every
 operation that modifies the filesystem must honour the `dry_run` flag. This is a
@@ -59,18 +61,24 @@ code 1.
 
 ## 3. Toolchain and development environment
 
-- **Package manager**: `uv` exclusively. No `pip`, no `poetry`, no direct venv activation or
-  deactivation. All interactions go through `uv` subcommands. `uv pip` must also be avoided.
-- **Running**: `uv run <command>` — e.g. `uv run pytest`, `uv run ruff format .`,
-  `uv run molim`. `uv run` resolves the project virtualenv automatically.
-- **Dependencies**: `uv sync --frozen` installs the locked set from `uv.lock` (committed).
-  `uv add <package>` / `uv add --dev <package>` for adding new dependencies.
-- **Building**: `uv build` produces wheel and sdist in `dist/`.
-- **Python version**: managed by uv from `.python-version` / `requires-python` in
-  `pyproject.toml`. No assumption about system Python.
+The toolchain choice serves the **Self-contained environment** principle: developing molim
+requires `uv` and the three external CLI tools on PATH (`rawtherapee-cli`, `convert`,
+`ffmpeg`) — nothing else on the host.
 
-  The only external prerequisites are the three CLI tools on PATH (`rawtherapee-cli`,
-  `convert`, `ffmpeg`). See the **Self-contained environment** principle.
+`uv` covers the entire Python lifecycle — environment provisioning, dependency management,
+build, and command invocation. A single tool subsumes the roles that would otherwise be
+split among `pip`, `virtualenv`, `poetry`, and others. This is what reduces the Python-side
+host prerequisite to one tool.
+
+**Dependency reproducibility** — the resolved dependency set is pinned in `uv.lock`,
+committed to the repository. Environments provisioned from the lock file are deterministic
+across hosts.
+
+**Python version** — defined by `.python-version` and `requires-python` in `pyproject.toml`.
+`uv` materialises the interpreter on demand; no assumption is made about a system Python.
+
+The build system (`hatchling` + `hatch-vcs`) and release pipeline are described in
+**Build, release, and distribution**.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -50,8 +50,10 @@ implementations. See **Dry-run mode**.
 
 **Fail fast** — invalid state is detected and reported at the earliest possible point.
 External tool availability is verified at processor instantiation, not at first use. Input
-validation is applied at every internal API boundary via the `check` module. Errors propagate
-to the top-level handler; unexpected failures are not silently swallowed.
+validation is applied at every internal API boundary via the `check` module. There are no
+catch-all handlers in commands or processors — errors propagate to the top-level handler in
+`main()`, which maps `KeyboardInterrupt` to exit code 130 and all other exceptions to exit
+code 1.
 
 ---
 
@@ -95,6 +97,8 @@ Source lives under `src/molim/`. Image-specific functionality is grouped in `src
 | `images/resize.py` | `ResizeCommand` — resizes JPEG via ImageMagick `-resize` |
 | `images/rawtherapee.py` | `RawTherapeeCommand` and `RawTherapeeHQCommand` — batch RAW processing via RawTherapee profiles; `RawTherapeeHQCommand` uses higher quality defaults |
 
+`show` is the sole channel for user-facing output. `print()` and the `logging` module are not used in application code.
+
 ---
 
 ## 5. Processing pipeline
@@ -132,7 +136,7 @@ Strategy composition in `Command._execute()`:
 
 `Command` in `commands.py` is the abstract base class. It implements the Template Method
 pattern: `_execute()` is the fixed template that orchestrates every processing run.
-Subclasses implement hook methods; they do not override `_execute()` — this is **Open/Closed** applied to the command pipeline. When overriding is unavoidable, `super()._execute(args)` must be called to augment rather than replace the pipeline. See `conventions.md` for the full override rules.
+Subclasses extend through the hook methods listed below, not by overriding `_execute()` — this is **Open/Closed** applied to the command pipeline.
 
 **Hooks subclasses must implement:**
 
@@ -161,14 +165,9 @@ command-specific arguments appear first in help output. `__call__(args)` delegat
 | `rawtherapee-hq` | `RawTherapeeHQCommand` | `images/rawtherapee.py` | `rawtherapee-cli` |
 | `suffix` | `SuffixCommand` | `rename.py` | — (Python stdlib only) |
 
-**Mixin pattern**: `JpegifyCommand` and `ResizeCommand` inherit
-`(commands.Command, ImageMagickMixin)`. `ImageMagickMixin` encapsulates all ImageMagick
-integration: it adds `--imagemagick-quality` and `--imagemagick-additional` CLI arguments, and
-provides the `ImageMagickFileProcessor` that constructs and runs the `convert` invocation.
-Because `Command` is listed first in the MRO, Python resolves `Command`'s abstract methods
-before the mixin's implementations, so subclasses must explicitly delegate `_add_arguments`
-and `_get_file_processor` to `ImageMagickMixin`. See `conventions.md` for the full mixin
-delegation pattern.
+**Mixin pattern**: ImageMagick integration is supplied as a mixin so `JpegifyCommand` and
+`ResizeCommand` can compose ImageMagick behaviour without altering the primary `Command`
+hierarchy.
 
 ---
 
@@ -256,14 +255,6 @@ tools. It uses the `sh` library.
 - **Dry-run**: `process()` logs the intended invocation and skips `_execute()` when
   `dry_run=True`.
 
-Tool-specific processors:
-
-| Processor | Tool | Argument shape |
-|---|---|---|
-| `FfmpegFileProcessor` | `ffmpeg` | `-y -i <in> -vcodec <codec> -crf <rate> [extra] [-report] <out>` |
-| `ImageMagickFileProcessor` | `convert` | `<in> [-quality N] [extra] <out>` |
-| `RawTherapeeFileProcessor` | `rawtherapee-cli` | `-o <out> -q -d -Y -p <profile.pp3> -j<quality> -js<subsampling> -c <in>` |
-
 **RawTherapee profile resolution** (first match wins):
 1. `--profile-folder` CLI argument
 2. `profile-folder` key in config file
@@ -296,27 +287,15 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 
 ## 12. Tests
 
-- **Approach**: the suite contains both focused unit tests and integration tests that invoke
-  real external tools (`rawtherapee-cli`, `convert`, `ffmpeg`). External tools are not mocked.
-  The three test categories map naturally to this split: input validation and dry-run tests
-  do not invoke external tools; core logic tests do.
+- **Approach**: the suite contains both unit tests and integration tests that invoke real
+  external tools (`rawtherapee-cli`, `convert`, `ffmpeg`). There is no mock layer for
+  external tools; integration tests require the tools to be installed.
 - **Location**: `tests/` at repo root, alongside `src/`.
-- **File naming**: `{module}_test.py` (e.g. `video_test.py`). When a module's tests are
-  large enough to split: `{module}_{aspect}_test.py` (e.g. `processing_files_test.py`,
-  `processing_folders_test.py`).
 - **Shared fixtures and constants**: `tests/common.py`.
-- **Static test data**: `tests/data/{module}/` — sample media files and config files needed
-  by tests that require real inputs.
-- **Temporary filesystem state**: `tmp_path` (function-scoped) and `tmp_path_factory`
-  (module-scoped) pytest fixtures. Temp state must be always cleaned up as a teardown step - no matter if the test passes or fails.
-- **`monkeypatch`**: permitted only for infrastructure concerns where no real tool exists
-  (e.g. stubbing `importlib.metadata.version()` for version detection). Never used to
-  substitute external CLI tools.
-- **Test categories per class**: input validation, dry-run behavior, core logic.
-- **Runner**: pytest with branch coverage (`pytest-cov`); reports uploaded to Codecov in CI.
-- **Coverage requirement**: tests are not optional. Every new class or method requires tests.
-  Every bug fix requires a regression test that validates the corrected behavior and catches
-  future regressions at the test stage.
+- **Static test data**: `tests/data/{module}/` — sample media files and config files for
+  tests that require real inputs.
+- **Runner**: pytest with branch coverage (`pytest-cov`); coverage data uploaded to Codecov
+  in CI.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -296,8 +296,10 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 
 ## 12. Tests
 
-- **Approach**: real integration tests — `rawtherapee-cli`, `convert`, and `ffmpeg` are
-  invoked for real. No mocking of external tools.
+- **Approach**: the suite contains both focused unit tests and integration tests that invoke
+  real external tools (`rawtherapee-cli`, `convert`, `ffmpeg`). External tools are not mocked.
+  The three test categories map naturally to this split: input validation and dry-run tests
+  do not invoke external tools; core logic tests do.
 - **Location**: `tests/` at repo root, alongside `src/`.
 - **File naming**: `{module}_test.py` (e.g. `video_test.py`). When a module's tests are
   large enough to split: `{module}_{aspect}_test.py` (e.g. `processing_files_test.py`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -196,11 +196,14 @@ expose and adding as many command-specific arguments as needed. Commands with no
 originals handling (e.g. `suffix`) suppress that slot by returning `None`; the argument does
 not appear in their help text or namespace.
 
-**Constraints**: the tuple returned by `_get_common_arguments_defaults()` is a fixed
-four-element contract between the base class and all subclasses. Adding a new common argument
-requires updating `_add_common_arguments()`, the `_get_common_arguments_defaults()` signature,
-and the return statement in every existing subclass. This coupling is intentional — common
-arguments are shared concern and changes to them are codebase-wide.
+**Constraints**: `_get_common_arguments_defaults()` returns a fixed four-element tuple
+`(extension, greater_than, no_skip_processed, originals)`. The first element sets the default
+for `--extension` but cannot suppress it — `--extension` is always added regardless of the
+value returned. The remaining three act differently: a non-`None` value sets the default and
+adds the argument; `None` suppresses it entirely. This mixed behaviour — one always-present
+element and three suppressible ones packed into the same tuple — is a design inconsistency.
+Adding a new element to the tuple requires updating `_add_common_arguments()`, the method
+signature, and every subclass return statement — changes are codebase-wide.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -279,8 +279,12 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
   `--config`.
 - **Structure**: TOML with a `[global]` section and per-command sections (e.g.
   `[rawtherapee]`).
-- **Lookup order**: `ConfigReader.__call__(key)` checks the command-specific section first,
-  then `[global]`.
+- **Lookup order**: `ConfigReader.__call__(key)` applies a two-level fallback chain. First
+  it checks the command-specific section, named after the command's `name` property (e.g.
+  `[rawtherapee]` for `RawTherapeeCommand`, `[video]` for `VideoFfmpegCommand`). If the key
+  is absent there, it falls back to `[global]`. If absent in both, it returns `None`. Callers
+  treat `None` as "not configured" and fall back to the CLI argument value or a hardcoded
+  constant.
 - **Fully opt-in**: no config file, no section, no entry — each is independently optional.
   Processing continues normally at every level of absence. There are no required entries.
   Configuration is additive: commands opt in to reading config values; nothing is compulsory.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,12 +67,8 @@ to the top-level handler; unexpected failures are not silently swallowed.
 - **Python version**: managed by uv from `.python-version` / `requires-python` in
   `pyproject.toml`. No assumption about system Python.
 
-  The development environment is **Self-contained**: after `uv sync --frozen`, the project
-  can be built, tested, and run with no further setup. The only external prerequisites are
-  the three CLI tools on PATH (`rawtherapee-cli`, `convert`, `ffmpeg`) — their installation
-  is a documented requirement, not a hidden assumption. No other system-level dependencies
-  exist. Self-containment is a design goal: new features must be designed to preserve it.
-  Introducing a dependency on a new system tool or library requires explicit justification.
+  The only external prerequisites are the three CLI tools on PATH (`rawtherapee-cli`,
+  `convert`, `ffmpeg`). See the **Self-contained environment** principle (§2).
 
 ---
 
@@ -128,7 +124,7 @@ Strategy composition in `Command._execute()`:
 8. Run `FolderProcessor(folder, matcher, skipper, processor).process(dry_run, show_size)`.
 9. Display `FolderStats`.
 
-**Composition approach**: dependencies are wired manually — no DI framework. Each class accepts its dependencies as constructor parameters (`__init__`). There are no singletons or shared mutable instances. `Command._execute()` is the composition root: it instantiates all strategies and processors, wires them together, and passes them into `FolderProcessor`. This explicit, constructor-based composition is a design goal and must be followed when adding new processors or strategies.
+`Command._execute()` is the composition root (see **IoC/DI**, §2): it instantiates all strategies and processors and wires them into `FolderProcessor`.
 
 ---
 
@@ -136,7 +132,7 @@ Strategy composition in `Command._execute()`:
 
 `Command` in `commands.py` is the abstract base class. It implements the Template Method
 pattern: `_execute()` is the fixed template that orchestrates every processing run.
-Subclasses implement hook methods; they do not override `_execute()`. Overriding the template method is a conscious, exceptional deviation — the hook methods are the correct and expected extension point. When overriding is unavoidable, `super()._execute(args)` must be called to augment rather than replace the pipeline. See `conventions.md` for the full override rules.
+Subclasses implement hook methods; they do not override `_execute()` — this is **Open/Closed** (§2) applied to the command pipeline. When overriding is unavoidable, `super()._execute(args)` must be called to augment rather than replace the pipeline. See `conventions.md` for the full override rules.
 
 **Hooks subclasses must implement:**
 
@@ -179,8 +175,9 @@ delegation pattern.
 ## 7. CLI composability
 
 The CLI uses argparse subparsers: one per command, each with a fully isolated argument
-namespace. Adding a new command requires no changes to the dispatch machinery in `cli` module; it just needs to instantiate
-the class and pass it to `_create_parser()`.
+namespace. Adding a new command requires no changes to the dispatch machinery in `cli` —
+instantiate the class and pass it to `_create_parser()`. This is **Open/Closed** (§2)
+applied to the CLI.
 
 **Three-tier argument structure:**
 
@@ -224,15 +221,14 @@ When `dry_run=True`:
 - Input validation, output path computation, and stats reporting still run in full — the
   user sees exactly what would happen.
 
-Every new `FileProcessor` and `PostProcessingStrategy` implementation must honour the
-`dry_run` flag. It is not optional.
+See the **Dry-run universality** principle (§2).
 
 ---
 
 ## 9. Strategy families
 
 `processing.py` defines six pluggable behaviour families. New variants are added by
-subclassing the appropriate ABC — no conditionals in base classes.
+subclassing the appropriate ABC — no conditionals in base classes (**Open/Closed**, §2).
 
 | Family ABC | Concrete variants | Controls |
 |---|---|---|
@@ -251,7 +247,8 @@ subclassing the appropriate ABC — no conditionals in base classes.
 tools. It uses the `sh` library.
 
 - **Tool verification**: the constructor calls `sh.Command(command)` and runs
-  `_get_verify_args()` at instantiation — fails fast if the tool is missing from PATH.
+  `_get_verify_args()` at instantiation — fails fast if the tool is missing from PATH
+  (**Fail fast**, §2).
 - **Argument construction**: `_finalize_args(input_path, output_path)` is abstract; each
   subclass constructs the tool-specific argument list from the input and output file paths.
 - **Dry-run**: `process()` logs the intended invocation and skips `_execute()` when

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ folder according to the command's rules.
 ## 2. Toolchain and development environment
 
 - **Package manager**: `uv` exclusively. No `pip`, no `poetry`, no direct venv activation or
-  deactivation. All interactions go through `uv` subcommands. `uv pip` must also be avoided. 
+  deactivation. All interactions go through `uv` subcommands. `uv pip` must also be avoided.
 - **Running**: `uv run <command>` — e.g. `uv run pytest`, `uv run ruff format .`,
   `uv run molim`. `uv run` resolves the project virtualenv automatically.
 - **Dependencies**: `uv sync --frozen` installs the locked set from `uv.lock` (committed).
@@ -24,11 +24,11 @@ folder according to the command's rules.
 - **Python version**: managed by uv from `.python-version` / `requires-python` in
   `pyproject.toml`. No assumption about system Python.
 
-  The development environment is **Self-contained**: after `uv sync --frozen`, the project 
-  can be built, tested, and run with no further setup. The only external prerequisites are 
-  the three CLI tools on PATH (`rawtherapee-cli`, `convert`, `ffmpeg`) — their installation 
-  is a documented requirement, not a hidden assumption. No other system-level dependencies 
-  exist. Self-containment is a design goal: new features must be designed to preserve it. 
+  The development environment is **Self-contained**: after `uv sync --frozen`, the project
+  can be built, tested, and run with no further setup. The only external prerequisites are
+  the three CLI tools on PATH (`rawtherapee-cli`, `convert`, `ffmpeg`) — their installation
+  is a documented requirement, not a hidden assumption. No other system-level dependencies
+  exist. Self-containment is a design goal: new features must be designed to preserve it.
   Introducing a dependency on a new system tool or library requires explicit justification.
 
 ---
@@ -54,7 +54,7 @@ Source lives under `src/molim/`. Image-specific functionality is grouped in `src
 | `images/imagemagick.py` | `ImageMagickMixin` and `ImageMagickFileProcessor` |
 | `images/jpegify.py` | `JpegifyCommand` — converts PNG / WebP / AVIF / HEIC to JPEG via ImageMagick |
 | `images/resize.py` | `ResizeCommand` — resizes JPEG via ImageMagick `-resize` |
-| `images/rawtherapee.py` | `RawTherapeeCommand`, `RawTherapeeHQCommand`, `RawTherapeeFileProcessor` ([TODO]: need short explanation as in other rows) |
+| `images/rawtherapee.py` | `RawTherapeeCommand` and `RawTherapeeHQCommand` — batch RAW processing via RawTherapee profiles; `RawTherapeeHQCommand` uses higher quality defaults |
 
 ---
 
@@ -85,7 +85,7 @@ Strategy composition in `Command._execute()`:
 8. Run `FolderProcessor(folder, matcher, skipper, processor).process(dry_run, show_size)`.
 9. Display `FolderStats`.
 
-[TODO]: add details on the code-level composition approach: manual dependency injection (constructor-based, no DI framework, just classess accepting their deps as __init__ params), no singleton or shared instances, Command as a composition root for processors and strategy instances (inside `_execute`). This approach to DI and composition is a design goal and should be followed.
+**Composition approach**: dependencies are wired manually — no DI framework. Each class accepts its dependencies as constructor parameters (`__init__`). There are no singletons or shared mutable instances. `Command._execute()` is the composition root: it instantiates all strategies and processors, wires them together, and passes them into `FolderProcessor`. This explicit, constructor-based composition is a design goal and must be followed when adding new processors or strategies.
 
 ---
 
@@ -93,7 +93,7 @@ Strategy composition in `Command._execute()`:
 
 `Command` in `commands.py` is the abstract base class. It implements the Template Method
 pattern: `_execute()` is the fixed template that orchestrates every processing run.
-Subclasses implement hook methods; they do not override `_execute()`. [TODO]: refer to conventions.md for the _execute() override rules and consistently reflect it here.
+Subclasses implement hook methods; they do not override `_execute()`. Overriding the template method is a conscious, exceptional deviation — the hook methods are the correct and expected extension point. When overriding is unavoidable, `super()._execute(args)` must be called to augment rather than replace the pipeline. See `conventions.md` for the full override rules.
 
 **Hooks subclasses must implement:**
 
@@ -123,9 +123,13 @@ command-specific arguments appear first in help output. `__call__(args)` delegat
 | `suffix` | `SuffixCommand` | `rename.py` | — (Python stdlib only) |
 
 **Mixin pattern**: `JpegifyCommand` and `ResizeCommand` inherit
-`(commands.Command, ImageMagickMixin)`. Because `Command` is listed first in the MRO,
-subclasses must explicitly delegate `_add_arguments` and `_get_file_processor` to
-`ImageMagickMixin`. [TODO]: add details what the mixin is doing. Refer to conventions.md
+`(commands.Command, ImageMagickMixin)`. `ImageMagickMixin` encapsulates all ImageMagick
+integration: it adds `--imagemagick-quality` and `--imagemagick-args` CLI arguments, and
+provides the `ImageMagickFileProcessor` that constructs and runs the `convert` invocation.
+Because `Command` is listed first in the MRO, Python resolves `Command`'s abstract methods
+before the mixin's implementations, so subclasses must explicitly delegate `_add_arguments`
+and `_get_file_processor` to `ImageMagickMixin`. See `conventions.md` for the full mixin
+delegation pattern.
 
 ---
 
@@ -235,12 +239,12 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
   `[rawtherapee]`).
 - **Lookup order**: `ConfigReader.__call__(key)` checks the command-specific section first,
   then `[global]`.
-- **Absence is valid**: if the config file does not exist, processing continues without it.
-  No config file is required.
-  
-  [TODO]: Add even more specific guidance on the optional, additional nature of the configuration subsystem. No file - okay. No section in the file - okay. No entry in the section  - okay. No required entries in the config file.
-  Configuration is fully opt-in by the commands, there is nothing compulsory about it.
-  At design time, the question "should this be configurable in `config.toml`" is always good to ask, because there are no technical constraints that push towards adding configurable options.
+- **Fully opt-in**: no config file, no section, no entry — each is independently optional.
+  Processing continues normally at every level of absence. There are no required entries.
+  Configuration is additive: commands opt in to reading config values; nothing is compulsory.
+  At design time, "should this be configurable in `config.toml`?" is always worth asking —
+  there are no technical constraints that push toward adding configurable options, so the
+  decision is purely about user value.
 
 ---
 
@@ -262,8 +266,9 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
   substitute external CLI tools.
 - **Test categories per class**: input validation, dry-run behavior, core logic.
 - **Runner**: pytest with branch coverage (`pytest-cov`); reports uploaded to Codecov in CI.
-
-[TODO]: add guidelines on the test coverage. Tests are not optional. Every new class or method requires tests. Every bug fix requires tests that validate the corrected behavior and ensure that regressions will be detected at unit test stage.
+- **Coverage requirement**: tests are not optional. Every new class or method requires tests.
+  Every bug fix requires a regression test that validates the corrected behaviour and catches
+  future regressions at the test stage.
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,290 @@
+# molim — Architecture
+
+## 1. Overview
+
+molim is a personal Linux CLI for batch file processing. It wraps three external tools —
+RawTherapee (`rawtherapee-cli`), ImageMagick (`convert`), and FFmpeg (`ffmpeg`) — behind a
+single consistent interface.
+
+The execution model is a single invocation: `molim <command> FOLDER [options]`. Each
+invocation selects one command, targets one folder, and processes all matching files in that
+folder according to the command's rules.
+
+---
+
+## 2. Tooling
+
+- **Package manager**: `uv` exclusively. No `pip`, no `poetry`, no direct venv activation or
+  deactivation. All interactions go through `uv` subcommands.
+- **Running**: `uv run <command>` — e.g. `uv run pytest`, `uv run ruff format .`,
+  `uv run molim`. `uv run` resolves the project virtualenv automatically.
+- **Dependencies**: `uv sync --frozen` installs the locked set from `uv.lock` (committed).
+  `uv add <package>` / `uv add --dev <package>` for adding new dependencies.
+- **Building**: `uv build` produces wheel and sdist in `dist/`.
+- **Python version**: managed by uv from `.python-version` / `requires-python` in
+  `pyproject.toml`. No assumption about system Python.
+- **Self-contained**: after `uv sync --frozen`, the project can be built, tested, and run
+  with no further setup. The only external prerequisites are the three CLI tools on PATH
+  (`rawtherapee-cli`, `convert`, `ffmpeg`) — their installation is a documented requirement,
+  not a hidden assumption. No other system-level dependencies exist. Self-containment is a
+  design goal: new features must be designed to preserve it. Introducing a dependency on a
+  new system tool or library requires explicit justification.
+
+---
+
+## 3. Package layout
+
+Source lives under `src/molim/`. Image-specific commands are grouped in `src/molim/images/`.
+
+| Module | Responsibility |
+|---|---|
+| `__init__.py` | Entry point; `main()` calls `cli.run()`; top-level exception handling (exit codes 130 / 1) |
+| `cli.py` | Command registry; instantiates all concrete commands; argparse dispatch |
+| `commands.py` | `Command` ABC (Template Method); shared CLI arguments; argument converter types |
+| `processing.py` | Strategy ABCs and concrete variants for output naming, post-processing, file matching, skipping, and per-file processing; `FolderProcessor` |
+| `shell.py` | `ShellCommandFileProcessor`; wraps the `sh` library for external CLI tool invocation |
+| `config.py` | TOML config loader; `ConfigReader`; per-command and global section lookup |
+| `check.py` | Input validation functions (type, path, range, format checks) |
+| `show.py` | All user-facing output via Rich; progress bars, size/time formatting, verbose gating |
+| `stats.py` | `FileStats` and `FolderStats` context managers for per-file and summary statistics |
+| `video.py` | `VideoFfmpegCommand` and `FfmpegFileProcessor` |
+| `rename.py` | `SuffixCommand` and `RenameFileProcessor` (filesystem rename, no shell) |
+| `images/__init__.py` | Shared image-domain constants (`JPEG_QUALITY`, `JPEG_PROCESSED_EXTENSION`, etc.) |
+| `images/imagemagick.py` | `ImageMagickMixin` and `ImageMagickFileProcessor` |
+| `images/jpegify.py` | `JpegifyCommand` — converts PNG / WebP / AVIF / HEIC to JPEG via ImageMagick |
+| `images/resize.py` | `ResizeCommand` — resizes JPEG via ImageMagick `-resize` |
+| `images/rawtherapee.py` | `RawTherapeeCommand`, `RawTherapeeHQCommand`, `RawTherapeeFileProcessor` |
+
+---
+
+## 4. Processing pipeline
+
+Execution flow from invocation to filesystem output:
+
+```
+molim <cmd> FOLDER              # __init__.main() → cli.run(sys.argv[1:])
+  └─ argparse dispatch           # cli._create_parser() → args.command(args)
+       └─ Command._execute()     # loads config, composes strategies
+            └─ FolderProcessor.process()        # iterates folder
+                 └─ FileProcessor.process()     # per matched, non-skipped file
+                      └─ ShellCommandFileProcessor._execute()   # sh.Command(...)
+                           └─ rawtherapee-cli / convert / ffmpeg
+```
+
+Strategy composition in `Command._execute()`:
+
+1. Resolve and validate `FOLDER` path.
+2. Load TOML config (command-specific section).
+3. Instantiate `OutputFilePathStrategy` via `_get_output_file_path_strategy(args)`.
+4. Instantiate `PostProcessingStrategy` via `_get_post_processing_strategy(folder, args)`.
+5. Instantiate `FileProcessor` via `_get_file_processor(args, output_namer, post_processor)`.
+6. Instantiate `FileMatchStrategy` via `_get_file_match_strategy(args)`.
+7. Instantiate `FileSkipStrategy` via `_get_file_skip_strategy(args)`, then wrap with
+   config-driven glob skips from `_get_global_skip_strategy()`.
+8. Run `FolderProcessor(folder, matcher, skipper, processor).process(dry_run, show_size)`.
+9. Display `FolderStats`.
+
+---
+
+## 5. Command framework
+
+`Command` in `commands.py` is the abstract base class. It implements the Template Method
+pattern: `_execute()` is the fixed template that orchestrates every processing run.
+Subclasses implement hook methods; they do not override `_execute()`.
+
+**Hook methods subclasses must implement:**
+
+| Method | Returns |
+|---|---|
+| `name` (property) | CLI subcommand name string |
+| `help` (property) | Help text string |
+| `_add_arguments(parser)` | Adds command-specific argparse arguments |
+| `_get_common_arguments_defaults()` | Tuple of defaults / `None` values for the four common slots |
+| `_get_output_file_path_strategy(args)` | An `OutputFilePathStrategy` instance |
+| `_get_file_processor(args, output_namer, post_processor)` | A `FileProcessor` instance |
+| `_get_file_skip_strategy(args)` | A `FileSkipStrategy` instance |
+
+`configure_parser()` calls `_add_arguments()` then `_add_common_arguments()` —
+command-specific arguments appear first in help output. `__call__(args)` delegates to
+`_execute()`; commands are callable objects registered via `parser.set_defaults(command=self)`.
+
+**Registered commands** (instantiated in `cli.run()`):
+
+| Command | Class | Module | External tool |
+|---|---|---|---|
+| `video` | `VideoFfmpegCommand` | `video.py` | `ffmpeg` |
+| `jpegify` | `JpegifyCommand` | `images/jpegify.py` | `convert` (ImageMagick) |
+| `resize` | `ResizeCommand` | `images/resize.py` | `convert` (ImageMagick) |
+| `rawtherapee` | `RawTherapeeCommand` | `images/rawtherapee.py` | `rawtherapee-cli` |
+| `rawtherapee-hq` | `RawTherapeeHQCommand` | `images/rawtherapee.py` | `rawtherapee-cli` |
+| `suffix` | `SuffixCommand` | `rename.py` | — (filesystem only) |
+
+**Mixin pattern**: `JpegifyCommand` and `ResizeCommand` inherit
+`(commands.Command, ImageMagickMixin)`. Because `Command` is listed first in the MRO,
+subclasses must explicitly delegate `_add_arguments` and `_get_file_processor` to
+`ImageMagickMixin`.
+
+---
+
+## 6. CLI composability
+
+The CLI uses argparse subparsers — one per command, each with a fully isolated argument
+namespace. Adding a new command requires no changes to the dispatch machinery: instantiate
+the class and pass it to `_create_parser()`.
+
+**Two-tier argument structure:**
+
+- *Always-present* — every command unconditionally: `FOLDER` (positional), `--config`,
+  `--dry-run`, `--verbose`. Added by `_add_common_arguments()`; cannot be suppressed.
+- *Optional common slots* — four shared arguments each command opts into or suppresses by
+  returning a default value or `None` from `_get_common_arguments_defaults()`:
+  - `--extension` — file extension filter
+  - `--greater-than` — minimum file size threshold
+  - `--no-skip-processed` — disable already-processed file detection by suffix
+  - `--originals` — post-processing disposition (`leave` / `move` / `delete`)
+- *Command-specific* — arbitrary additional arguments defined in `_add_arguments()`, scoped
+  entirely to that command (e.g. `--codec`, `--profile`, `--imagemagick-quality`).
+
+**Flexibility**: commands compose their own argument surface by choosing which common slots to
+expose and adding as many command-specific arguments as needed. Commands with no concept of
+originals handling (e.g. `suffix`) suppress that slot by returning `None`; the argument does
+not appear in their help text or namespace.
+
+**Constraints**: the optional common slot tuple is a fixed four-element contract between the
+base class and all subclasses. Adding a new optional common argument requires updating
+`_add_common_arguments()`, the `_get_common_arguments_defaults()` signature, and the return
+statement in every existing subclass. This coupling is intentional — common arguments are
+shared infrastructure and changes to them are codebase-wide.
+
+---
+
+## 7. Dry-run mode
+
+Dry-run is a first-class feature present on every command. `--dry-run` is defined in
+`Command._add_common_arguments()` and propagated through the entire processing pipeline.
+
+When `dry_run=True`:
+
+- `Command._execute()` passes the flag to `FolderProcessor.process()`.
+- `FolderProcessor` passes it to each `FileProcessor.process()` call.
+- `ShellCommandFileProcessor` logs the intended command but does not invoke the external
+  tool.
+- `RenameFileProcessor` logs the intended rename but does not call `Path.rename()`.
+- `PostProcessingStrategy` implementations (move, delete) skip their filesystem operations.
+- Input validation, output path computation, and stats reporting still run in full — the
+  user sees exactly what would happen.
+
+Every new `FileProcessor` and `PostProcessingStrategy` implementation must honour the
+`dry_run` flag. It is not optional.
+
+---
+
+## 8. Strategy families
+
+`processing.py` defines six pluggable behaviour families. New variants are added by
+subclassing the appropriate ABC — no conditionals in base classes.
+
+| Family ABC | Concrete variants | Controls |
+|---|---|---|
+| `OutputFilePathStrategy` | `SuffixOutputFilePathStrategy`, `ChangeExtOutputFilePathStrategy`, `FolderOutputFilePathStrategy`, `MultiOutputFilePathStrategy` | How output files are named and where they are placed |
+| `PostProcessingStrategy` | `NoopPostProcessingStrategy`, `MoveOriginalPostProcessingStrategy`, `DeleteOriginalPostProcessingStrategy`, `ReplaceOriginalWithProcessedPostProcessingStrategy` | What happens to the original file after processing |
+| `FileMatchStrategy` | `AnyFileMatchStrategy`, `ByExtensionFileMatchStrategy` | Which files in a folder are considered for processing |
+| `FileSkipStrategy` | `BySuffixFileSkipStrategy`, `BySizeFileSkipStrategy`, `GlobFileSkipStrategy`, `MultiFileSkipStrategy` | Which matched files are skipped |
+| `FileProcessor` | `ShellCommandFileProcessor` subtypes, `RenameFileProcessor` | How a single file is processed |
+| (orchestrator) | `FolderProcessor` | Iterates the folder, applies match / skip / process, aggregates `FolderStats` |
+
+---
+
+## 9. External tool integration
+
+`ShellCommandFileProcessor` in `shell.py` is the bridge between Python and external CLI
+tools. It uses the `sh` library.
+
+- **Tool verification**: the constructor calls `sh.Command(command)` and runs
+  `_get_verify_args()` at instantiation — fails fast if the tool is missing from PATH.
+- **Argument construction**: `_finalize_args(input_path, output_path)` is abstract; each
+  subclass constructs the tool-specific argument list from the input and output file paths.
+- **Dry-run**: `process()` logs the intended invocation and skips `_execute()` when
+  `dry_run=True`.
+
+Tool-specific processors:
+
+| Processor | Tool | Argument shape |
+|---|---|---|
+| `FfmpegFileProcessor` | `ffmpeg` | `-y -i <in> -vcodec <codec> -crf <rate> [extra] [-report] <out>` |
+| `ImageMagickFileProcessor` | `convert` | `<in> [-quality N] [extra] <out>` |
+| `RawTherapeeFileProcessor` | `rawtherapee-cli` | `-o <out> -q -d -p <profile.pp3> -Y -j<quality> -js<subsampling> -c <in>` |
+
+**RawTherapee profile resolution** (first match wins):
+1. `--profile-folder` CLI argument
+2. `profile-folder` key in config file
+3. Default: `~/.config/RawTherapee/profiles`
+
+Profile name: `--profile` CLI argument → config `profile` key → default `molim`.
+
+---
+
+## 10. Configuration
+
+- **File location**: `~/.config/molim/config.toml` (default); overridden per invocation via
+  `--config`.
+- **Structure**: TOML with a `[global]` section and per-command sections (e.g.
+  `[rawtherapee]`).
+- **Lookup order**: `ConfigReader.__call__(key)` checks the command-specific section first,
+  then `[global]`.
+- **Absence is valid**: if the config file does not exist, processing continues without it.
+  No config file is required.
+
+---
+
+## 11. Tests
+
+- **Approach**: real integration tests — `rawtherapee-cli`, `convert`, and `ffmpeg` are
+  invoked for real. No mocking of external tools.
+- **Location**: `tests/` at repo root, alongside `src/`.
+- **File naming**: `{module}_test.py` (e.g. `video_test.py`). When a module's tests are
+  large enough to split: `{module}_{aspect}_test.py` (e.g. `processing_files_test.py`,
+  `processing_folders_test.py`).
+- **Shared fixtures and constants**: `tests/common.py`.
+- **Static test data**: `tests/data/{module}/` — sample media files and config files needed
+  by tests that require real inputs.
+- **Temporary filesystem state**: `tmp_path` (function-scoped) and `tmp_path_factory`
+  (module-scoped) pytest fixtures.
+- **`monkeypatch`**: permitted only for infrastructure concerns where no real tool exists
+  (e.g. stubbing `importlib.metadata.version()` for version detection). Not used to
+  substitute external CLI tools.
+- **Test categories per class**: input validation, dry-run behavior, core logic.
+- **Runner**: pytest with branch coverage (`pytest-cov`); reports uploaded to Codecov in CI.
+
+---
+
+## 12. Build, release, and distribution
+
+- **Build system**: `hatchling` + `hatch-vcs` (`pyproject.toml`). `uv build` produces a
+  wheel and source distribution in `dist/`.
+- **Versioning**: derived from git tags via `hatch-vcs` (`source = "vcs"`). A `vX.Y.Z` tag
+  on `main` sets the release version. Untagged commits fall back to `0.0.0.dev0`.
+- **Entry point**: `molim = "molim:main"` in `[project.scripts]` — the installed package
+  provides the `molim` CLI command.
+- **Release workflow** (`.github/workflows/release.yml`): triggered by a `v*` tag push.
+  Runs the full base CI, then builds the package and creates a GitHub Release with the wheel
+  and sdist attached. Release notes are auto-generated by GitHub from merged PRs.
+- **Distribution**: GitHub Releases only. molim is a personal tool and is not published to
+  PyPI. Users install from a GitHub Release artifact (e.g. `uv tool install` from the wheel
+  URL or directly from the repository).
+
+---
+
+## 13. Continuous integration
+
+- **CI workflow** (`.github/workflows/ci.yml`): runs on every push to any branch and every
+  pull request. Delegates to `base.yml`.
+- **Release workflow** also runs `base.yml` as a prerequisite, so the same checks gate every
+  release.
+- **Base workflow** (`.github/workflows/base.yml`): three parallel jobs:
+  - `run_pytest` — installs system tools (`rawtherapee`, `imagemagick`, `ffmpeg`), runs
+    `uv run pytest` with branch coverage; uploads HTML report as a workflow artifact and
+    coverage data to Codecov.
+  - `lint` — runs `uv run ruff format --check .` and `uv run ruff check .`; no auto-fix,
+    fails on violations.
+  - `scan_secrets` — full-history `gitleaks` scan on every run.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -313,7 +313,7 @@ Profile name: `--profile` CLI argument → config `profile` key → default `mol
 - **Test categories per class**: input validation, dry-run behavior, core logic.
 - **Runner**: pytest with branch coverage (`pytest-cov`); reports uploaded to Codecov in CI.
 - **Coverage requirement**: tests are not optional. Every new class or method requires tests.
-  Every bug fix requires a regression test that validates the corrected behaviour and catches
+  Every bug fix requires a regression test that validates the corrected behavior and catches
   future regressions at the test stage.
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,22 +31,22 @@ machinery. Existing base classes and templates are not modified to accommodate n
 **Composability** — complex behaviour is assembled from small, single-purpose objects.
 `Command._execute()` composes a pipeline from independently replaceable strategy instances.
 The same strategy types are reused across commands; commands differ by the combination they
-assemble, not by internal branching. See §6 (Command framework) and §9 (Strategy families).
+assemble, not by internal branching. See **Command framework** and **Strategy families**.
 
 **Inversion of Control / Dependency Injection** — components receive their dependencies via
 constructors. There is no DI framework and no service locator. `Command._execute()` is the
 composition root: it instantiates all strategies and processors and wires them together.
-There are no singletons or shared mutable instances. See §5 (Processing pipeline).
+There are no singletons or shared mutable instances. See **Processing pipeline**.
 
 **Self-contained environment** — after `uv sync --frozen`, the project builds, tests, and
 runs with no further setup. The only external prerequisites are the three CLI tools on PATH.
 New features must preserve this. Introducing a dependency on a new system tool or library
-requires explicit justification. See §3 (Toolchain).
+requires explicit justification. See **Toolchain and development environment**.
 
 **Dry-run universality** — `--dry-run` is a first-class feature, not an afterthought. Every
 operation that modifies the filesystem must honour the `dry_run` flag. This is a
 non-negotiable constraint on all new `FileProcessor` and `PostProcessingStrategy`
-implementations. See §8 (Dry-run mode).
+implementations. See **Dry-run mode**.
 
 **Fail fast** — invalid state is detected and reported at the earliest possible point.
 External tool availability is verified at processor instantiation, not at first use. Input
@@ -68,7 +68,7 @@ to the top-level handler; unexpected failures are not silently swallowed.
   `pyproject.toml`. No assumption about system Python.
 
   The only external prerequisites are the three CLI tools on PATH (`rawtherapee-cli`,
-  `convert`, `ffmpeg`). See the **Self-contained environment** principle (§2).
+  `convert`, `ffmpeg`). See the **Self-contained environment** principle.
 
 ---
 
@@ -124,7 +124,7 @@ Strategy composition in `Command._execute()`:
 8. Run `FolderProcessor(folder, matcher, skipper, processor).process(dry_run, show_size)`.
 9. Display `FolderStats`.
 
-`Command._execute()` is the composition root (see **IoC/DI**, §2): it instantiates all strategies and processors and wires them into `FolderProcessor`.
+`Command._execute()` is the composition root (see **IoC/DI**): it instantiates all strategies and processors and wires them into `FolderProcessor`.
 
 ---
 
@@ -132,7 +132,7 @@ Strategy composition in `Command._execute()`:
 
 `Command` in `commands.py` is the abstract base class. It implements the Template Method
 pattern: `_execute()` is the fixed template that orchestrates every processing run.
-Subclasses implement hook methods; they do not override `_execute()` — this is **Open/Closed** (§2) applied to the command pipeline. When overriding is unavoidable, `super()._execute(args)` must be called to augment rather than replace the pipeline. See `conventions.md` for the full override rules.
+Subclasses implement hook methods; they do not override `_execute()` — this is **Open/Closed** applied to the command pipeline. When overriding is unavoidable, `super()._execute(args)` must be called to augment rather than replace the pipeline. See `conventions.md` for the full override rules.
 
 **Hooks subclasses must implement:**
 
@@ -163,7 +163,7 @@ command-specific arguments appear first in help output. `__call__(args)` delegat
 
 **Mixin pattern**: `JpegifyCommand` and `ResizeCommand` inherit
 `(commands.Command, ImageMagickMixin)`. `ImageMagickMixin` encapsulates all ImageMagick
-integration: it adds `--imagemagick-quality` and `--imagemagick-args` CLI arguments, and
+integration: it adds `--imagemagick-quality` and `--imagemagick-additional` CLI arguments, and
 provides the `ImageMagickFileProcessor` that constructs and runs the `convert` invocation.
 Because `Command` is listed first in the MRO, Python resolves `Command`'s abstract methods
 before the mixin's implementations, so subclasses must explicitly delegate `_add_arguments`
@@ -176,16 +176,15 @@ delegation pattern.
 
 The CLI uses argparse subparsers: one per command, each with a fully isolated argument
 namespace. Adding a new command requires no changes to the dispatch machinery in `cli` —
-instantiate the class and pass it to `_create_parser()`. This is **Open/Closed** (§2)
-applied to the CLI.
+instantiate the class and pass it to `_create_parser()`. This is **Open/Closed** applied to the CLI.
 
 **Three-tier argument structure:**
 
 - *Always-present* — every command must support unconditionally: `FOLDER` (positional), `--config`,
-  `--dry-run`, `--verbose`. Added by `_add_common_arguments()`; cannot be suppressed.
-- *Optional common slots* — four shared arguments each command opts into or suppresses by
+  `--dry-run`, `--verbose`, `--extension`. Added by `_add_common_arguments()`; cannot be
+  suppressed. Commands supply the default for `--extension` via `_get_common_arguments_defaults()`.
+- *Optional common slots* — three shared arguments each command opts into or suppresses by
   returning a default value or `None` from `_get_common_arguments_defaults()`:
-  - `--extension` — file extension filter
   - `--greater-than` — minimum file size threshold
   - `--no-skip-processed` — disable already-processed file detection by suffix
   - `--originals` — post-processing disposition (`leave` / `move` / `delete`)
@@ -197,11 +196,11 @@ expose and adding as many command-specific arguments as needed. Commands with no
 originals handling (e.g. `suffix`) suppress that slot by returning `None`; the argument does
 not appear in their help text or namespace.
 
-**Constraints**: the optional common slot tuple is a fixed four-element contract between the
-base class and all subclasses. Adding a new optional common argument requires updating
-`_add_common_arguments()`, the `_get_common_arguments_defaults()` signature, and the return
-statement in every existing subclass. This coupling is intentional — common arguments are
-shared concern and changes to them are codebase-wide.
+**Constraints**: the tuple returned by `_get_common_arguments_defaults()` is a fixed
+four-element contract between the base class and all subclasses. Adding a new common argument
+requires updating `_add_common_arguments()`, the `_get_common_arguments_defaults()` signature,
+and the return statement in every existing subclass. This coupling is intentional — common
+arguments are shared concern and changes to them are codebase-wide.
 
 ---
 
@@ -221,21 +220,21 @@ When `dry_run=True`:
 - Input validation, output path computation, and stats reporting still run in full — the
   user sees exactly what would happen.
 
-See the **Dry-run universality** principle (§2).
+See the **Dry-run universality** principle.
 
 ---
 
 ## 9. Strategy families
 
 `processing.py` defines six pluggable behaviour families. New variants are added by
-subclassing the appropriate ABC — no conditionals in base classes (**Open/Closed**, §2).
+subclassing the appropriate ABC — no conditionals in base classes (**Open/Closed**).
 
 | Family ABC | Concrete variants | Controls |
 |---|---|---|
 | `OutputFilePathStrategy` | `SuffixOutputFilePathStrategy`, `ChangeExtOutputFilePathStrategy`, `FolderOutputFilePathStrategy`, `MultiOutputFilePathStrategy` | How output files are named and where they are placed |
-| `PostProcessingStrategy` | `NoopPostProcessingStrategy`, `MoveOriginalPostProcessingStrategy`, `DeleteOriginalPostProcessingStrategy`, `ReplaceOriginalWithProcessedPostProcessingStrategy` | What happens to the original file after processing |
+| `PostProcessingStrategy` | `NoopPostProcessingStrategy`, `MoveOriginalPostProcessingStrategy`, `DeleteOriginalPostProcessingStrategy`, `ReplaceOriginalPostProcessignStrategy` | What happens to the original file after processing |
 | `FileMatchStrategy` | `AnyFileMatchStrategy`, `ByExtensionFileMatchStrategy` | Which files in a folder are considered for processing |
-| `FileSkipStrategy` | `BySuffixFileSkipStrategy`, `BySizeFileSkipStrategy`, `GlobFileSkipStrategy`, `MultiFileSkipStrategy` | Which matched files are skipped |
+| `FileSkipStrategy` | `NoFileSkipStrategy`, `BySuffixFileSkipStrategy`, `BySizeFileSkipStrategy`, `GlobFileSkipStrategy`, `MultiFileSkipStrategy` | Which matched files are skipped |
 | `FileProcessor` | `ShellCommandFileProcessor` subtypes, `RenameFileProcessor` | How a single file is processed |
 | (orchestrator) | `FolderProcessor` | Iterates the folder, applies match / skip / process, aggregates `FolderStats` |
 
@@ -248,7 +247,7 @@ tools. It uses the `sh` library.
 
 - **Tool verification**: the constructor calls `sh.Command(command)` and runs
   `_get_verify_args()` at instantiation — fails fast if the tool is missing from PATH
-  (**Fail fast**, §2).
+  (**Fail fast**).
 - **Argument construction**: `_finalize_args(input_path, output_path)` is abstract; each
   subclass constructs the tool-specific argument list from the input and output file paths.
 - **Dry-run**: `process()` logs the intended invocation and skips `_execute()` when
@@ -260,7 +259,7 @@ Tool-specific processors:
 |---|---|---|
 | `FfmpegFileProcessor` | `ffmpeg` | `-y -i <in> -vcodec <codec> -crf <rate> [extra] [-report] <out>` |
 | `ImageMagickFileProcessor` | `convert` | `<in> [-quality N] [extra] <out>` |
-| `RawTherapeeFileProcessor` | `rawtherapee-cli` | `-o <out> -q -d -p <profile.pp3> -Y -j<quality> -js<subsampling> -c <in>` |
+| `RawTherapeeFileProcessor` | `rawtherapee-cli` | `-o <out> -q -d -Y -p <profile.pp3> -j<quality> -js<subsampling> -c <in>` |
 
 **RawTherapee profile resolution** (first match wins):
 1. `--profile-folder` CLI argument

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -99,6 +99,25 @@ Import from the module that owns the concept. Avoid broad dependency reach-throu
 
 ---
 
+## Tooling
+
+Use `uv` for all Python work — environment, dependencies, build, and running project commands. Daily operations:
+
+```bash
+uv run pytest                     # run tests
+uv run ruff format .              # format
+uv run ruff check .               # lint
+uv run pre-commit run --all-files
+uv run molim                      # invoke the CLI
+uv build                          # build wheel + sdist
+```
+
+Provision dependencies with `uv sync --frozen` — installs the pinned set from `uv.lock`. Run after cloning or when `uv.lock` changes. New dependencies are added with `uv add` (runtime) or `uv add --dev` (dev) — see Dependencies for when this is allowed.
+
+Do not use `pip`, `poetry`, or `uv pip`. Do not manually activate or deactivate the project virtualenv.
+
+---
+
 ## Dependencies
 
 Do not add runtime, development, or system dependencies unless the implementation plan explicitly calls for them. If the implementation appears to require a new dependency, escalate to the Project Owner via PM rather than adding it opportunistically.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -99,6 +99,12 @@ Import from the module that owns the concept. Avoid broad dependency reach-throu
 
 ---
 
+## Dependencies
+
+Do not add runtime, development, or system dependencies unless the implementation plan explicitly calls for them. If the implementation appears to require a new dependency, escalate to the Project Owner via PM rather than adding it opportunistically.
+
+---
+
 ## Adding a command
 
 1. Create or choose a module in `src/molim/` (or `src/molim/images/` for image commands). Create a new module for a new functional area; reuse an existing module for closely related command variants that share most implementation.
@@ -132,7 +138,7 @@ Import from the module that owns the concept. Avoid broad dependency reach-throu
        def _add_arguments(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
            return parser
 
-       def _get_common_arguments_defaults(self) -> tuple[str, str, bool, str]:
+       def _get_common_arguments_defaults(self) -> tuple[str, str | None, bool | None, str | None]:
            return (self.EXTENSION, self.GREATER_THAN, self.NO_SKIP_PROCESSED, self.ORIGINALS)
 
        def _get_output_file_path_strategy(self, args: argparse.Namespace) -> processing.OutputFilePathStrategy:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -80,22 +80,6 @@ Use `pathlib.Path` for all filesystem paths inside application logic. Convert in
 
 ## Module layout
 
-```
-src/molim/
-├── __init__.py       # Entry point: main()
-├── cli.py            # CLI runner and command list
-├── commands.py       # Command base class and argument types
-├── check.py          # Input validation functions
-├── config.py         # Config file reader
-├── processing.py     # Strategy classes for file processing
-├── rename.py         # Rename (suffix) command
-├── shell.py          # Shell execution wrapper
-├── show.py           # User-facing output
-├── stats.py          # Statistics context managers
-├── video.py          # Video processing command
-└── images/           # Image-specific commands and processors
-```
-
 One module per functional area. Image-processing commands go under `images/`. New commands usually get their own module file; closely related command variants may share a module when they share most of their implementation. When adding new functionality, decide first whether it belongs in an existing cross-cutting module (`check`, `processing`, `shell`, `show`) or in a domain-specific command module — do not let `cli.py` or `commands.py` grow into catch-all implementation files.
 
 ---
@@ -193,7 +177,7 @@ The codebase uses nominal typing rather than duck typing. New implementations mu
 
 **Template Method** (`commands.py`) — `Command._execute()` orchestrates the processing pipeline. Subclasses implement the hook methods. Do not override `_execute` unless there is no other way to achieve the required behaviour — see the rule in the Adding a command section.
 
-**Strategy** (`processing.py`) — pluggable behaviours for output path naming, post-processing, file matching, and file skipping. Add new variants by subclassing the appropriate abstract base: `OutputFilePathStrategy`, `PostProcessingStrategy`, `FileMatchStrategy`, `FileSkipStrategy`, `FileProcessor`. Before adding conditionals to an existing method, consider whether the new behaviour should instead be a new strategy, a command subclass, or a mixin. Use composition for pipelines: combine behaviours through `Multi*` strategies rather than hard-coding special cases. `MultiOutputFilePathStrategy` applies strategies sequentially. Do not assume combined strategies are commutative; test the final output path explicitly when composing multiple strategies. Keep concerns separate: output naming belongs in `OutputFilePathStrategy`; moving, deleting, or replacing originals belongs in `PostProcessingStrategy`.
+**Strategy** (`processing.py`) — pluggable behaviours for output path naming, post-processing, file matching, and file skipping. Before adding conditionals to an existing method, consider whether the new behaviour should instead be a new strategy, a command subclass, or a mixin. Use composition for pipelines: combine behaviours through `Multi*` strategies rather than hard-coding special cases. `MultiOutputFilePathStrategy` applies strategies sequentially. Do not assume combined strategies are commutative; test the final output path explicitly when composing multiple strategies. Keep concerns separate: output naming belongs in `OutputFilePathStrategy`; moving, deleting, or replacing originals belongs in `PostProcessingStrategy`.
 
 **Mixin** — injects shared functionality into classes alongside their primary inheritance line. Use a mixin when multiple command classes need the same cross-cutting capability that does not belong in the `Command` base class. Example: `ImageMagickMixin` provides the complete ImageMagick integration — argument parsing, validation, and the `ImageMagickFileProcessor` that runs `convert`. Classes using the mixin are still proper `Command` subclasses; the mixin adds a second axis of behaviour without altering the primary hierarchy.
 
@@ -232,7 +216,7 @@ In application code, use the `show` module for all user-facing output. Never use
 
 `show.set_verbose(args.verbose)` is called once in `cli.py`. Call `show.verbose()` freely; the module manages the gate.
 
-The module also provides lower-level formatting helpers (`human_size`, `elapsed`, `percent`, `ext`, `ellipsis`) and `verbose_args`. Use them when appropriate rather than reimplementing equivalent formatting inline.
+The table above is a quick reference, not an exhaustive list. The module also provides lower-level formatting helpers (`human_size`, `elapsed`, `percent`, `ext`, `ellipsis`) and `verbose_args`. For anything not listed, consult `show.py` directly. If no existing function fits the need, consider whether a new `show.*` function should be added rather than using `print()` or inline formatting.
 
 ---
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -123,7 +123,7 @@ Import from the module that owns the concept. Avoid broad dependency reach-throu
    - `name` (`@property`) → `str` — CLI subcommand name
    - `help` (`@property`) → `str` — help text
    - `_add_arguments(parser)` → adds command-specific argparse arguments; returns parser
-   - `_get_common_arguments_defaults()` → returns `(extension, greater_than, no_skip_processed, originals)` tuple; pass `None` for any optional common argument to suppress it
+   - `_get_common_arguments_defaults()` → returns `(extension, greater_than, no_skip_processed, originals)` tuple; `extension` must always be a non-`None` string (`--extension` is always present); pass `None` for any of the other three to suppress that argument
    - `_get_output_file_path_strategy(args)` → returns an `OutputFilePathStrategy`
    - `_get_file_processor(args, output_namer, post_processor)` → returns a `FileProcessor`
    - `_get_file_skip_strategy(args)` → returns a `FileSkipStrategy`
@@ -172,7 +172,7 @@ Import from the module that owns the concept. Avoid broad dependency reach-throu
    - **Package-level** (e.g., `images/__init__.py`): a shared domain fact used by multiple commands in the same package (`JPEG_QUALITY`, `JPEG_PROCESSED_EXTENSION`).
 
    Name class-level constants according to their role:
-   - **Common arg slot defaults** — constants that supply default values for the four shared CLI arguments (`extension`, `greater_than`, `no_skip_processed`, `originals`) use **unprefixed** names: `EXTENSION`, `GREATER_THAN`, `NO_SKIP_PROCESSED`, `ORIGINALS`. The same name appears in every command that sets that slot, making cross-command comparison immediate.
+   - **Common arg slot defaults** — constants that supply default values for the common CLI arguments (`extension`, `greater_than`, `no_skip_processed`, `originals`) use **unprefixed** names: `EXTENSION`, `GREATER_THAN`, `NO_SKIP_PROCESSED`, `ORIGINALS`. `EXTENSION` is always a non-`None` string; the other three may be `None` to suppress the argument. The same name appears in every command that sets that slot, making cross-command comparison immediate.
    - **Command-specific constants** — constants tied to a command's own functionality (not a common slot) use a **command-prefixed** name: `VIDEO_FFMPEG_CODEC`, `RAWTHERAPEE_PROCESSED_SUFFIX`.
 5. Use kebab-case for all CLI flags: `--dry-run`, `--greater-than`, `--imagemagick-quality`.
 6. Register the command in `cli.py` by instantiating it in `run()` and passing it to `_create_parser(...)`.
@@ -347,7 +347,7 @@ Every new behaviour requires tests. Every bug fix requires a regression test.
 
 - Test files: `{module}_test.py` (e.g., `video_test.py`) — not `test_{module}.py`. When a module's tests are large enough to warrant splitting, use `{module}_{aspect}_test.py` (e.g., `processing_files_test.py`, `processing_folders_test.py`).
 - Test functions: `test_{Subject}_{description}` where `Subject` is a class name or module-level function name, and `description` is a free label — typically a section keyword (`input_validation`, `dry_run`, `core_logic`) or a specific method or scenario (`name`, `create_parser`, `empty_folder`).
-- Use `tmp_path` (function-scoped) and `tmp_path_factory` (module-scoped) for temporary filesystem state
+- Use `tmp_path` (function-scoped) and `tmp_path_factory` (module-scoped) for temporary filesystem state. Pytest cleans up both automatically. Do not create test state outside these fixtures; if unavoidable, add an explicit teardown that runs whether the test passes or fails.
 - Static test data (sample media files, config files) goes in `tests/data/{module}/` — create the folder only when the module's tests actually need static files
 - Shared fixtures and path constants used across multiple test modules go in `tests/common.py`
 


### PR DESCRIPTION
## What this PR does

Adds `docs/architecture.md` — a codebase-reference document for AA at design time — and refines the boundary between `architecture.md`, `conventions.md`, and `impl-plan.md` so the three roles (AA, Coder, PM) have coherent, audience-scoped documentation.

Highlights:

- **New `architecture.md`** (14 sections): overview, design principles charter, toolchain rationale, package layout, processing pipeline, command framework, CLI composability, dry-run, strategy families, external tool integration, configuration, tests, build/release/distribution, CI.
- **`conventions.md` updates**: new Tooling and Dependencies sections; corrected command skeleton return annotation; trimmed content that belongs in architecture; preserved Coder-facing rules.
- **`AGENTIC-SDLC.md` updates**: Phase 4 impl-plan formalized as `Architecture context` + `Work breakdown`; subagent delegation scoped by audience; AA must escalate when impl-plan needs design not in `tech-design.md`.

The final model: `architecture.md` is AA's design map; `conventions.md` is the AA + Coder rulebook; `impl-plan.md` carries task-specific architecture context to Coder. Audience separation is preserved — no cross-references between `architecture.md` and `conventions.md`.

Closes #38

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI / configuration

## Checklist

- [x] All tests pass (`uv run pytest`)
- [ ] New functionality is covered by tests
- [x] Code is formatted and linted (`uv run pre-commit run --all-files`)
- [x] PR title is a clear, human-readable summary of the change