### PR TITLE
Quality Gates: bash script + project config (#68)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,6 +3,7 @@
     "skill-creator@claude-plugins-official": true
   },
   "permissions": {
+    "additionalDirectories": ["/tmp"],
     "allow": [
       "Bash(git *)",
       "Bash(gh issue *)",
@@ -20,7 +21,7 @@
       "Bash(uv run pre-commit *)",
       "Bash(uv run molim *)",
       "Bash(scripts/quality-gates.sh)",
-      "Read(/tmp/quality-gates-*)",
+      "Bash(jq *)",
       "Skill(new-issue)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:code.claude.com)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,7 @@
       "Bash(uv run ruff *)",
       "Bash(uv run pre-commit *)",
       "Bash(uv run molim *)",
+      "Bash(scripts/quality-gates.sh)",
       "Skill(new-issue)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:code.claude.com)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,7 @@
       "Bash(uv run pre-commit *)",
       "Bash(uv run molim *)",
       "Bash(scripts/quality-gates.sh)",
+      "Read(/tmp/quality-gates-*)",
       "Skill(new-issue)",
       "WebFetch(domain:github.com)",
       "WebFetch(domain:code.claude.com)",

--- a/.quality-gates.conf
+++ b/.quality-gates.conf
@@ -1,0 +1,6 @@
+# molim quality gates
+# Commands are run sequentially, all checks run regardless of failures.
+# Order matters: auto-fixers before verifiers, formatter before linter.
+uv run ruff format .
+uv run ruff check --fix .
+uv run pytest

--- a/.quality-gates.conf
+++ b/.quality-gates.conf
@@ -1,6 +1,6 @@
 # molim quality gates
 # Commands are run sequentially, all checks run regardless of failures.
-# Order matters: auto-fixers before verifiers, formatter before linter.
-uv run ruff format .
+# Order matters: auto-fixers before verifiers, linter before formatter.
 uv run ruff check --fix .
+uv run ruff format .
 uv run pytest

--- a/docs/AGENTIC-SDLC.md
+++ b/docs/AGENTIC-SDLC.md
@@ -228,11 +228,25 @@ The skill writes only to `CHANGELOG.md`. The invoking agent (AA) handles the com
 
 - **Purpose:** Run all project quality checks (tests, format, lint) and produce a unified pass/fail report.
 - **Inputs:** None (operates on current working directory of Git branch checkout).
-- **Outputs:** Structured pass/fail report with per-check results and failure details.
+- **Outputs:** `PASS` or `FAIL` per check printed to stdout with progress; path to a JSON result file containing per-check status and full output for all checks.
 - **Permissions required:** `shell:exec`, `fs:read`, `fs:write`.
 - **Invoked by:** Coder, in Phase 5.
+- **Implementation:** Bash script at `scripts/quality-gates.sh`. Not a model-based skill — deterministic, zero LLM cost.
 
 `fs:write` access is required for formatting and linting tools to modify codebase and for tests to store any output artifacts (e.g. coverage report).
+
+**Project artifact required:** `.quality-gates.conf` at repo root. Each non-blank, non-`#` line is one check command, run sequentially. All checks run regardless of failures (run-all). Order matters: place auto-fixers (formatters, `--fix` variants) before pure verifiers so verifiers run on already-fixed code.
+
+**JSON result file format:**
+```json
+{
+  "overall": "PASS",
+  "checks": [
+    { "command": "uv run ruff format .", "status": "PASS", "output": "" },
+    { "command": "uv run pytest", "status": "FAIL", "output": "...full output..." }
+  ]
+}
+```
 
 #### Cut Release
 

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Quality gates runner.
+# Reads .quality-gates.conf from the git repo root, runs each check sequentially,
+# and writes a JSON result file. All checks run regardless of failures (run-all).
+#
+# Stdout:
+#   [N/total] <command>   — before each check
+#   PASS | FAIL           — after each check
+#   PASS | FAIL           — overall result (final line before Results)
+#   Results: <path>       — path to JSON result file
+#
+# Exit code: 0 if all checks passed, 1 if any failed.
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CONF="$REPO_ROOT/.quality-gates.conf"
+RESULT_FILE=$(mktemp /tmp/quality-gates-XXXXXX.json)
+
+if [[ ! -f "$CONF" ]]; then
+    echo "Error: $CONF not found" >&2
+    exit 2
+fi
+
+# Read commands from config, skipping blank lines and comments
+commands=()
+while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+    commands+=("$line")
+done < "$CONF"
+
+if [[ ${#commands[@]} -eq 0 ]]; then
+    echo "Error: no checks defined in $CONF" >&2
+    exit 2
+fi
+
+overall="PASS"
+checks_json="[]"
+total=${#commands[@]}
+
+for i in "${!commands[@]}"; do
+    cmd="${commands[$i]}"
+    n=$((i + 1))
+
+    echo "[$n/$total] $cmd"
+
+    output=$(eval "$cmd" 2>&1) && exit_code=0 || exit_code=$?
+
+    if [[ $exit_code -eq 0 ]]; then
+        status="PASS"
+    else
+        status="FAIL"
+        overall="FAIL"
+    fi
+
+    echo "$status"
+
+    checks_json=$(
+        printf '%s' "$output" | jq -Rs \
+            --argjson checks "$checks_json" \
+            --arg cmd "$cmd" \
+            --arg status "$status" \
+            '$checks + [{"command": $cmd, "status": $status, "output": .}]'
+    )
+done
+
+jq -n \
+    --arg overall "$overall" \
+    --argjson checks "$checks_json" \
+    '{"overall": $overall, "checks": $checks}' > "$RESULT_FILE"
+
+echo "$overall"
+echo "Results: $RESULT_FILE"
+
+[[ "$overall" == "PASS" ]]

--- a/scripts/quality-gates.sh
+++ b/scripts/quality-gates.sh
@@ -6,6 +6,7 @@
 # Stdout:
 #   [N/total] <command>   — before each check
 #   PASS | FAIL           — after each check
+#   ===					  — delimiter between last check result and overall result 
 #   PASS | FAIL           — overall result (final line before Results)
 #   Results: <path>       — path to JSON result file
 #
@@ -15,6 +16,7 @@ set -uo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 CONF="$REPO_ROOT/.quality-gates.conf"
+cd "$REPO_ROOT"
 RESULT_FILE=$(mktemp /tmp/quality-gates-XXXXXX.json)
 
 if [[ ! -f "$CONF" ]]; then
@@ -69,6 +71,7 @@ jq -n \
     --argjson checks "$checks_json" \
     '{"overall": $overall, "checks": $checks}' > "$RESULT_FILE"
 
+echo "==="
 echo "$overall"
 echo "Results: $RESULT_FILE"
 


### PR DESCRIPTION
## Summary

- Adds `scripts/quality-gates.sh` — a generic SDLC-owned bash script that reads `.quality-gates.conf` from the repo root, runs all checks sequentially (run-all, no fail-fast), and writes a structured JSON result file to `/tmp`
- Adds `.quality-gates.conf` with molim's three checks: `ruff check --fix`, `ruff format`, `pytest`
- Updates `docs/AGENTIC-SDLC.md` Quality Gates entry with implementation details
- Adds `/tmp` as an `additionalDirectories` entry and `Bash(jq *)` permission in `.claude/settings.json` so the Coder agent can read result files and filter them without prompts

## Design notes

- Script is CWD-independent (`cd "$REPO_ROOT"` after `git rev-parse --show-toplevel`)
- All check outputs captured via `jq -Rs` for safe JSON encoding (handles newlines, quotes, control chars)
- Progressive discovery protocol: Coder reads overall status from stdout, then uses `jq` to filter failures before pulling full outputs — avoids bloating context with passing check output on failure
- Stdout format: `[N/total] <cmd>` → `PASS|FAIL` per check → `===` delimiter → overall `PASS|FAIL` → `Results: <path>`
- Exit codes: 0 = all pass, 1 = any fail, 2 = config error

## Test plan

- [x] Positive flow: `scripts/quality-gates.sh` exits 0, result JSON is valid
- [x] Read result file via Read tool, `cat`, and `jq` — all work without permission prompts
- [x] Negative flow: single ruff failure, single pytest failure, combined failure — all exit 1 with correct JSON

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)