### PR TITLE
Add check.ensure_type_or_none and eliminate conditional validation pattern

### DIFF
--- a/src/molim/check.py
+++ b/src/molim/check.py
@@ -13,6 +13,11 @@ def ensure_type(obj, type):
         raise TypeError(f"A {type} object is required.")
 
 
+def ensure_type_or_none(obj, type):
+    if obj is not None:
+        ensure_type(obj, type)
+
+
 def ensure_str_startswith(obj, start):
     ensure_type(obj, str)
     if not obj.startswith(start):

--- a/src/molim/config.py
+++ b/src/molim/config.py
@@ -29,10 +29,8 @@ class ConfigReader:
     GLOBAL_SECTION = "global"
 
     def __init__(self, document: tomlkit.toml_document.TOMLDocument, section: str):
-        if document is not None:
-            check.ensure_type(document, tomlkit.toml_document.TOMLDocument)
-        if section is not None:
-            check.ensure_type(section, str)
+        check.ensure_type_or_none(document, tomlkit.toml_document.TOMLDocument)
+        check.ensure_type_or_none(section, str)
         self.__doc = document
         self.__section = section
 

--- a/src/molim/images/imagemagick.py
+++ b/src/molim/images/imagemagick.py
@@ -22,8 +22,7 @@ class ImageMagickMixin:
 
     def _get_imagemagick_args(self, args: argparse.Namespace) -> list[str]:
         check.ensure_int_between(args.imagemagick_quality, 1, 100)
-        if args.imagemagick_additional is not None:
-            check.ensure_type(args.imagemagick_additional, str)
+        check.ensure_type_or_none(args.imagemagick_additional, str)
         cmdline = ["-quality", str(args.imagemagick_quality)]
         if args.imagemagick_additional is not None:
             cmdline += args.imagemagick_additional.split(" ")

--- a/src/molim/video.py
+++ b/src/molim/video.py
@@ -107,8 +107,7 @@ class FfmpegFileProcessor(shell.ShellCommandFileProcessor):
     ):
         check.ensure_type(ffmpeg_codec, str)
         check.ensure_int_between(ffmpeg_rate, 0, 51)
-        if ffmpeg_additional is not None:
-            check.ensure_type(ffmpeg_additional, str)
+        check.ensure_type_or_none(ffmpeg_additional, str)
         check.ensure_type(ffmpeg_report, bool)
 
         args = [

--- a/tests/check_test.py
+++ b/tests/check_test.py
@@ -1,0 +1,16 @@
+import pytest
+
+from molim import check
+
+
+def test_ensure_type_or_none_none_input():
+    check.ensure_type_or_none(None, str)
+
+
+def test_ensure_type_or_none_correct_type():
+    check.ensure_type_or_none("hello", str)
+
+
+def test_ensure_type_or_none_wrong_type():
+    with pytest.raises(TypeError):
+        check.ensure_type_or_none(42, str)


### PR DESCRIPTION
Closes #92

## Summary
- Added `ensure_type_or_none(obj, type)` to `check.py` — skips the type check when `obj is None`, delegates to `ensure_type` otherwise
- Replaced 4 conditional validation occurrences across `video.py`, `images/imagemagick.py`, and `config.py`
- Added `tests/check_test.py` with targeted tests for the three behaviours of the new helper

## Test plan
- [ ] `uv run pytest` — all tests pass
- [ ] `uv run ruff format .` — no changes
- [ ] `uv run ruff check .` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)