### PR TITLE
Move command constants to correct scope per conventions

### DIFF
--- a/src/molim/images/jpegify.py
+++ b/src/molim/images/jpegify.py
@@ -6,18 +6,18 @@ from .imagemagick import ImageMagickMixin
 
 
 class JpegifyCommand(commands.Command, ImageMagickMixin):
-    JPEGIFY_EXTENSION = ".png,.webp,.avif,.heic"
-    JPEGIFY_ORIGINALS = "delete"
+    EXTENSION = ".png,.webp,.avif,.heic"
+    ORIGINALS = "delete"
 
     def _add_arguments(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         return ImageMagickMixin._add_arguments(self, parser)
 
     def _get_common_arguments_defaults(self) -> tuple[str, str, bool, str]:
         return (
-            JpegifyCommand.JPEGIFY_EXTENSION,
+            JpegifyCommand.EXTENSION,
             None,  # Suppress greater-than parameter
             None,  # Suppress no-skip-processed parameter
-            JpegifyCommand.JPEGIFY_ORIGINALS,
+            JpegifyCommand.ORIGINALS,
         )
 
     def _get_output_file_path_strategy(self, args: argparse.Namespace) -> processing.OutputFilePathStrategy:

--- a/src/molim/images/rawtherapee.py
+++ b/src/molim/images/rawtherapee.py
@@ -4,18 +4,17 @@ import pathlib
 from .. import check, commands, processing, shell, show
 from . import JPEG_EXTENSION, JPEG_PROCESSED_EXTENSION, JPEG_QUALITY
 
-RAWTHERAPEE_PROFILE_FOLDER = pathlib.Path("~/.config/RawTherapee/profiles")
-RAWTHERAPEE_PROFILE_EXTENSION = ".pp3"
-RAWTHERAPEE_DEFAULT_PROFILE = "molim"
-
 
 class RawTherapeeCommand(commands.Command):
     GREATER_THAN = "2M"
     NO_SKIP_PROCESSED = False
     ORIGINALS = "move"
-    PROCESSED_SUFFIX = ".m"
+    RAWTHERAPEE_PROCESSED_SUFFIX = ".m"
     JPEG_QUALITY_80 = 80
     JPEG_SUBSAMPLING_2 = 2
+    RAWTHERAPEE_PROFILE_FOLDER = pathlib.Path("~/.config/RawTherapee/profiles")
+    RAWTHERAPEE_PROFILE_EXTENSION = ".pp3"
+    RAWTHERAPEE_DEFAULT_PROFILE = "molim"
 
     def _get_quality_defaults(self) -> tuple[int, int]:
         return (
@@ -30,7 +29,7 @@ class RawTherapeeCommand(commands.Command):
             help=(
                 "Location of RawTherapee profiles to use for processing. "
                 "If not specified as an argument or in configuration file, "
-                f"{RAWTHERAPEE_PROFILE_FOLDER} will be used."
+                f"{RawTherapeeCommand.RAWTHERAPEE_PROFILE_FOLDER} will be used."
             ),
         )
         parser.add_argument(
@@ -40,7 +39,7 @@ class RawTherapeeCommand(commands.Command):
                 "Name of RawTherapee profile to use for processing. "
                 "Name does not have the file extension, i.e., default and not default.pp3"
                 "If not specified as an argument or in configuration file, "
-                f"'{RAWTHERAPEE_DEFAULT_PROFILE}' will be used."
+                f"'{RawTherapeeCommand.RAWTHERAPEE_DEFAULT_PROFILE}' will be used."
             ),
         )
 
@@ -82,7 +81,7 @@ class RawTherapeeCommand(commands.Command):
 
     def _get_output_file_path_strategy(self, args: argparse.Namespace) -> processing.OutputFilePathStrategy:
         ext = processing.ChangeExtOutputFilePathStrategy(JPEG_PROCESSED_EXTENSION)
-        suffix = processing.SuffixOutputFilePathStrategy(RawTherapeeCommand.PROCESSED_SUFFIX)
+        suffix = processing.SuffixOutputFilePathStrategy(RawTherapeeCommand.RAWTHERAPEE_PROCESSED_SUFFIX)
         out = [ext, suffix]
         if args.processed_subfolder is not None:
             original_path = pathlib.Path(args.FOLDER).absolute()
@@ -97,16 +96,15 @@ class RawTherapeeCommand(commands.Command):
         post_processor: processing.PostProcessingStrategy,
     ) -> processing.FileProcessor:
         # Getting RawTherapee profile
-        profile_folder = (
-            pathlib.Path(args.profile_folder or self._get_config_value("profile-folder") or RAWTHERAPEE_PROFILE_FOLDER)
-            .expanduser()
-            .absolute()
+        raw_profile_folder = (
+            args.profile_folder or self._get_config_value("profile-folder") or RawTherapeeCommand.RAWTHERAPEE_PROFILE_FOLDER
         )
+        profile_folder = pathlib.Path(raw_profile_folder).expanduser().absolute()
         check.ensure_folder(profile_folder)
 
-        profile = args.profile or self._get_config_value("profile") or RAWTHERAPEE_DEFAULT_PROFILE
+        profile = args.profile or self._get_config_value("profile") or RawTherapeeCommand.RAWTHERAPEE_DEFAULT_PROFILE
         check.ensure_type(profile, str)
-        profile_name = f"{profile}{RAWTHERAPEE_PROFILE_EXTENSION}"
+        profile_name = f"{profile}{RawTherapeeCommand.RAWTHERAPEE_PROFILE_EXTENSION}"
         profile_path = profile_folder / profile_name
         show.normal(f"Using RawTherapee profile {profile_path}")
         check.ensure_file(profile_path)
@@ -123,7 +121,7 @@ class RawTherapeeCommand(commands.Command):
     def _get_file_skip_strategy(self, args: argparse.Namespace) -> processing.FileSkipStrategy:
         skips = []
         if not args.no_skip_processed:
-            skips.append(processing.BySuffixFileSkipStrategy(RawTherapeeCommand.PROCESSED_SUFFIX))
+            skips.append(processing.BySuffixFileSkipStrategy(RawTherapeeCommand.RAWTHERAPEE_PROCESSED_SUFFIX))
         if args.greater_than:
             skips.append(processing.BySizeFileSkipStrategy(args.greater_than))
         skipper = processing.MultiFileSkipStrategy(skips)

--- a/src/molim/images/resize.py
+++ b/src/molim/images/resize.py
@@ -7,7 +7,7 @@ from .imagemagick import ImageMagickMixin
 
 
 class ResizeCommand(commands.Command, ImageMagickMixin):
-    RESIZE_ORIGINALS = "delete"
+    ORIGINALS = "delete"
 
     def _add_arguments(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         parser = ImageMagickMixin._add_arguments(self, parser)
@@ -31,7 +31,7 @@ class ResizeCommand(commands.Command, ImageMagickMixin):
             JPEG_EXTENSION,
             None,  # Suppress greater-than parameter
             None,  # Suppress no-skip-processed parameter
-            ResizeCommand.RESIZE_ORIGINALS,
+            ResizeCommand.ORIGINALS,
         )
 
     def _get_post_processing_strategy(

--- a/src/molim/video.py
+++ b/src/molim/video.py
@@ -3,37 +3,39 @@ import pathlib
 
 from . import check, commands, processing, shell
 
-VIDEO_EXTENSION = ".mp4"
-VIDEO_GREATER_THAN = "30M"
-VIDEO_NO_SKIP_PROCESSED = False
-VIDEO_ORIGINALS = "move"
-VIDEO_PROCESSED_SUFFIX = ".min"
-VIDEO_PROCESSED_EXTENSION = ".mp4"
-VIDEO_FFMPEG_CODEC = "libx265"
-VIDEO_FFMPEG_RATE = 26
-
 
 class VideoFfmpegCommand(commands.Command):
+    EXTENSION = ".mp4"
+    GREATER_THAN = "30M"
+    NO_SKIP_PROCESSED = False
+    ORIGINALS = "move"
+    VIDEO_PROCESSED_SUFFIX = ".min"
+    VIDEO_PROCESSED_EXTENSION = ".mp4"
+    VIDEO_FFMPEG_CODEC = "libx265"
+    VIDEO_FFMPEG_RATE = 26
+    VIDEO_FFMPEG_ADDITIONAL = None
+    VIDEO_FFMPEG_REPORT = False
+
     def _add_arguments(self, parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         parser.add_argument(
             "--ffmpeg-codec",
-            default=VIDEO_FFMPEG_CODEC,
+            default=VideoFfmpegCommand.VIDEO_FFMPEG_CODEC,
             help="FFMpeg codec to use for processing.",
         )
         parser.add_argument(
             "--ffmpeg-rate",
-            default=VIDEO_FFMPEG_RATE,
+            default=VideoFfmpegCommand.VIDEO_FFMPEG_RATE,
             type=int,
             help="FFMpeg processing compression rate.",
         )
         parser.add_argument(
             "--ffmpeg-additional",
-            default=None,
+            default=VideoFfmpegCommand.VIDEO_FFMPEG_ADDITIONAL,
             help="Additional parameters for FFMpeg processing.",
         )
         parser.add_argument(
             "--ffmpeg-report",
-            default=False,
+            default=VideoFfmpegCommand.VIDEO_FFMPEG_REPORT,
             action="store_true",
             help="Write FFMpeg report with extended conversion information.",
         )
@@ -41,19 +43,19 @@ class VideoFfmpegCommand(commands.Command):
 
     def _get_common_arguments_defaults(self) -> tuple[str, str, str]:
         return (
-            VIDEO_EXTENSION,
-            VIDEO_GREATER_THAN,
-            VIDEO_NO_SKIP_PROCESSED,
-            VIDEO_ORIGINALS,
+            VideoFfmpegCommand.EXTENSION,
+            VideoFfmpegCommand.GREATER_THAN,
+            VideoFfmpegCommand.NO_SKIP_PROCESSED,
+            VideoFfmpegCommand.ORIGINALS,
         )
 
     def _get_output_file_path_strategy(self, args: argparse.Namespace) -> processing.OutputFilePathStrategy:
         output_namer = processing.MultiOutputFilePathStrategy(
             [
-                processing.SuffixOutputFilePathStrategy(VIDEO_PROCESSED_SUFFIX),
+                processing.SuffixOutputFilePathStrategy(VideoFfmpegCommand.VIDEO_PROCESSED_SUFFIX),
                 processing.ChangeExtOutputFilePathStrategy(
                     # Force output extension.
-                    VIDEO_PROCESSED_EXTENSION
+                    VideoFfmpegCommand.VIDEO_PROCESSED_EXTENSION
                 ),
             ]
         )
@@ -78,7 +80,7 @@ class VideoFfmpegCommand(commands.Command):
     def _get_file_skip_strategy(self, args: argparse.Namespace) -> processing.FileSkipStrategy:
         skips = []
         if not args.no_skip_processed:
-            skips.append(processing.BySuffixFileSkipStrategy(VIDEO_PROCESSED_SUFFIX))
+            skips.append(processing.BySuffixFileSkipStrategy(VideoFfmpegCommand.VIDEO_PROCESSED_SUFFIX))
         if args.greater_than:
             skips.append(processing.BySizeFileSkipStrategy(args.greater_than))
         skipper = processing.MultiFileSkipStrategy(skips)

--- a/tests/images_test.py
+++ b/tests/images_test.py
@@ -118,10 +118,10 @@ def test_JpegifyCommand_get_common_arguments_defaults():
     j = jpegify.JpegifyCommand()
     a, b, c, d = j._get_common_arguments_defaults()
 
-    assert a == jpegify.JpegifyCommand.JPEGIFY_EXTENSION
+    assert a == jpegify.JpegifyCommand.EXTENSION
     assert b is None
     assert c is None
-    assert d == jpegify.JpegifyCommand.JPEGIFY_ORIGINALS
+    assert d == jpegify.JpegifyCommand.ORIGINALS
 
 
 def test_JpegifyCommand_create_parser():
@@ -132,7 +132,7 @@ def test_JpegifyCommand_create_parser():
 
     assert args.FOLDER == "."
     assert args.dry_run
-    assert args.extension == jpegify.JpegifyCommand.JPEGIFY_EXTENSION
+    assert args.extension == jpegify.JpegifyCommand.EXTENSION
 
     # Ensure some common args are suppressed
     with pytest.raises(AttributeError):
@@ -154,7 +154,7 @@ def test_JpegifyCommand_args_validation():
                 FOLDER=str(JPEGIFY_FOLDER),
                 dry_run=True,
                 config=str(common.EMPTY_CONFIG),
-                extension=jpegify.JpegifyCommand.JPEGIFY_EXTENSION,
+                extension=jpegify.JpegifyCommand.EXTENSION,
                 originals=commands.OriginalsHandlingEnum.LEAVE,
                 imagemagick_quality=-5,
                 imagemagick_additional=None,
@@ -168,7 +168,7 @@ def test_JpegifyCommand_args_validation():
                 FOLDER=str(JPEGIFY_FOLDER),
                 dry_run=True,
                 config=str(common.EMPTY_CONFIG),
-                extension=jpegify.JpegifyCommand.JPEGIFY_EXTENSION,
+                extension=jpegify.JpegifyCommand.EXTENSION,
                 originals=commands.OriginalsHandlingEnum.LEAVE,
                 imagemagick_quality=120,
                 imagemagick_additional=None,
@@ -182,7 +182,7 @@ def test_JpegifyCommand_args_validation():
                 FOLDER=str(JPEGIFY_FOLDER),
                 dry_run=True,
                 config=str(common.EMPTY_CONFIG),
-                extension=jpegify.JpegifyCommand.JPEGIFY_EXTENSION,
+                extension=jpegify.JpegifyCommand.EXTENSION,
                 originals=commands.OriginalsHandlingEnum.LEAVE,
                 imagemagick_quality=90,
                 imagemagick_additional=True,
@@ -198,7 +198,7 @@ def test_JpegifyCommand_dry_run():
             FOLDER=str(JPEGIFY_FOLDER),
             dry_run=True,
             config=str(common.EMPTY_CONFIG),
-            extension=jpegify.JpegifyCommand.JPEGIFY_EXTENSION,
+            extension=jpegify.JpegifyCommand.EXTENSION,
             originals=commands.OriginalsHandlingEnum.LEAVE,
             imagemagick_quality=images.JPEG_QUALITY,
             imagemagick_additional=None,
@@ -219,7 +219,7 @@ def test_JpegifyCommand_core_logic():
             FOLDER=str(JPEGIFY_FOLDER),
             dry_run=False,
             config=str(common.EMPTY_CONFIG),
-            extension=jpegify.JpegifyCommand.JPEGIFY_EXTENSION,
+            extension=jpegify.JpegifyCommand.EXTENSION,
             originals=commands.OriginalsHandlingEnum.LEAVE,
             imagemagick_quality=images.JPEG_QUALITY,
             imagemagick_additional=None,
@@ -249,7 +249,7 @@ def test_ResizeCommand_get_common_arguments_defaults():
     assert a == images.JPEG_EXTENSION
     assert b is None
     assert c is None
-    assert d == resize.ResizeCommand.RESIZE_ORIGINALS
+    assert d == resize.ResizeCommand.ORIGINALS
 
 
 def test_ResizeCommand_get_post_processing_strategy(tmp_path):

--- a/tests/video_test.py
+++ b/tests/video_test.py
@@ -126,10 +126,10 @@ def test_VideoFfmpegCommand_get_common_arguments_defaults():
     v = video.VideoFfmpegCommand()
     a, b, c, d = v._get_common_arguments_defaults()
 
-    assert a == video.VIDEO_EXTENSION
-    assert b == video.VIDEO_GREATER_THAN
-    assert c == video.VIDEO_NO_SKIP_PROCESSED
-    assert d == video.VIDEO_ORIGINALS
+    assert a == video.VideoFfmpegCommand.EXTENSION
+    assert b == video.VideoFfmpegCommand.GREATER_THAN
+    assert c == video.VideoFfmpegCommand.NO_SKIP_PROCESSED
+    assert d == video.VideoFfmpegCommand.ORIGINALS
 
 
 def test_VideoFfmpegCommand_create_parser():
@@ -140,12 +140,12 @@ def test_VideoFfmpegCommand_create_parser():
 
     assert args.FOLDER == "."
     assert args.dry_run
-    assert args.extension == video.VIDEO_EXTENSION
+    assert args.extension == video.VideoFfmpegCommand.EXTENSION
     assert not args.no_skip_processed
-    assert args.greater_than == commands.HumanReadableSizeType()(video.VIDEO_GREATER_THAN)
+    assert args.greater_than == commands.HumanReadableSizeType()(video.VideoFfmpegCommand.GREATER_THAN)
     assert args.originals == commands.OriginalsHandlingEnum.MOVE
-    assert args.ffmpeg_codec == video.VIDEO_FFMPEG_CODEC
-    assert args.ffmpeg_rate == video.VIDEO_FFMPEG_RATE
+    assert args.ffmpeg_codec == video.VideoFfmpegCommand.VIDEO_FFMPEG_CODEC
+    assert args.ffmpeg_rate == video.VideoFfmpegCommand.VIDEO_FFMPEG_RATE
     assert args.ffmpeg_additional is None
     assert not args.ffmpeg_report
     assert not args.verbose


### PR DESCRIPTION
Closes #90

## Summary

- Moved 8 module-level constants in `video.py` to `VideoFfmpegCommand` class attributes; renamed the 4 common-slot ones to unprefixed names (`EXTENSION`, `GREATER_THAN`, `NO_SKIP_PROCESSED`, `ORIGINALS`); added 2 new named constants for previously inlined defaults (`VIDEO_FFMPEG_ADDITIONAL`, `VIDEO_FFMPEG_REPORT`)
- Moved 3 module-level constants in `rawtherapee.py` to `RawTherapeeCommand` class attributes; renamed `PROCESSED_SUFFIX` → `RAWTHERAPEE_PROCESSED_SUFFIX`
- Renamed `JpegifyCommand.JPEGIFY_EXTENSION` → `EXTENSION` and `JPEGIFY_ORIGINALS` → `ORIGINALS`
- Renamed `ResizeCommand.RESIZE_ORIGINALS` → `ORIGINALS`
- Updated all test references to match new locations and names

No behavioral changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)