### PR TITLE
Add missing type annotations across source modules (#87)

### DIFF
--- a/src/molim/check.py
+++ b/src/molim/check.py
@@ -1,58 +1,58 @@
 import pathlib
 
 
-def ensure_not_none(obj):
+def ensure_not_none(obj: object) -> None:
     if obj is None:
         raise ValueError("Value cannot be None.")
 
 
-def ensure_type(obj, type):
+def ensure_type(obj: object, type: type) -> None:
     ensure_not_none(obj)
     ensure_not_none(type)
     if not isinstance(obj, type):
         raise TypeError(f"A {type} object is required.")
 
 
-def ensure_type_or_none(obj, type):
+def ensure_type_or_none(obj: object, type: type) -> None:
     if obj is not None:
         ensure_type(obj, type)
 
 
-def ensure_str_startswith(obj, start):
+def ensure_str_startswith(obj: object, start: str) -> None:
     ensure_type(obj, str)
     if not obj.startswith(start):
         raise ValueError(f"A string value that starts with '{start}' is required (provided: {obj}).")
 
 
-def ensure_int_positive(obj):
+def ensure_int_positive(obj: object) -> None:
     ensure_type(obj, int)
     if obj < 1:
         raise ValueError(f"A positive integer value is required (provided: {obj}).")
 
 
-def ensure_int_between(obj, min, max):
+def ensure_int_between(obj: object, min: int, max: int) -> None:
     ensure_type(obj, int)
     if obj < min or obj > max:
         raise ValueError(f"An integer value between {min} and {max} is required (provided: {obj}).")
 
 
-def ensure_list_non_empty(obj):
+def ensure_list_non_empty(obj: object) -> None:
     ensure_type(obj, list)
     if len(obj) == 0:
         raise ValueError("A non-empty list is required.")
 
 
-def ensure_path(obj):
+def ensure_path(obj: object) -> None:
     ensure_type(obj, pathlib.Path)
 
 
-def ensure_file(obj):
+def ensure_file(obj: object) -> None:
     ensure_path(obj)
     if not obj.is_file():
         raise ValueError("A file is required.")
 
 
-def ensure_folder(obj):
+def ensure_folder(obj: object) -> None:
     ensure_path(obj)
     if not obj.is_dir():
         raise ValueError("A folder is required.")

--- a/src/molim/cli.py
+++ b/src/molim/cli.py
@@ -8,7 +8,7 @@ from .images import jpegify, rawtherapee, resize
 UNKNOWN_VERSION = "0.0.0-unknown"
 
 
-def __version():
+def __version() -> str:
     try:
         return version("molim")
     except PackageNotFoundError:

--- a/src/molim/commands.py
+++ b/src/molim/commands.py
@@ -71,7 +71,7 @@ class Command:
             Executes the command with the given arguments.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.__config = None
 
     # Private methods
@@ -156,10 +156,10 @@ class Command:
         return parser
 
     @property
-    def config(self):
+    def config(self) -> config.ConfigReader | None:
         return self.__config
 
-    def _get_config_value(self, key: str):
+    def _get_config_value(self, key: str) -> object | None:
         if self.config:
             value = self.config(key)
             show.verbose(f"Read configuration: {key} = {value}")
@@ -167,7 +167,7 @@ class Command:
         return None
 
     @property
-    def _move_to_subfolder_name(self):
+    def _move_to_subfolder_name(self) -> str:
         return "_orig"
 
     def _get_post_processing_strategy(
@@ -182,12 +182,12 @@ class Command:
             return processing.DeleteOriginalPostProcessingStrategy()
         raise ValueError(args.originals)
 
-    def _get_file_match_strategy(self, args: argparse.Namespace):
+    def _get_file_match_strategy(self, args: argparse.Namespace) -> processing.FileMatchStrategy:
         if args.extension == ANY_MATCH_EXTENSION:
             return processing.AnyFileMatchStrategy()
         return processing.ByExtensionFileMatchStrategy(args.extension)
 
-    def _get_global_skip_strategy(self, skip_strategy):
+    def _get_global_skip_strategy(self, skip_strategy: processing.FileSkipStrategy) -> processing.FileSkipStrategy:
         if not self.config:
             return skip_strategy
         skip_glob_list = self._get_config_value("skip")
@@ -202,7 +202,7 @@ class Command:
         return processing.MultiFileSkipStrategy(result)
 
     @property
-    def _show_size(self):
+    def _show_size(self) -> bool:
         return True
 
     def _execute(self, args: argparse.Namespace) -> stats.FolderStats:

--- a/src/molim/config.py
+++ b/src/molim/config.py
@@ -28,7 +28,7 @@ def load(config_path_str: str | None = None, section: str | None = None) -> "Con
 class ConfigReader:
     GLOBAL_SECTION = "global"
 
-    def __init__(self, document: tomlkit.toml_document.TOMLDocument, section: str):
+    def __init__(self, document: tomlkit.toml_document.TOMLDocument, section: str) -> None:
         check.ensure_type_or_none(document, tomlkit.toml_document.TOMLDocument)
         check.ensure_type_or_none(section, str)
         self.__doc = document

--- a/src/molim/config.py
+++ b/src/molim/config.py
@@ -9,7 +9,7 @@ from . import check, show
 DEFAULT_CONFIG_PATH = pathlib.Path("~/.config/molim/config.toml")
 
 
-def load(config_path_str: str = None, section: str = None):
+def load(config_path_str: str | None = None, section: str | None = None) -> "ConfigReader | None":
     if config_path_str is not None:
         config_path = pathlib.Path(config_path_str)
         check.ensure_file(config_path)
@@ -34,7 +34,7 @@ class ConfigReader:
         self.__doc = document
         self.__section = section
 
-    def _get_or_none(self, section, key):
+    def _get_or_none(self, section: str, key: str) -> object | None:
         if not self.__doc or not section or not key:
             return None
         try:
@@ -42,12 +42,12 @@ class ConfigReader:
         except tomlkit.exceptions.NonExistentKey:
             return None
 
-    def _get(self, key: str):
+    def _get(self, key: str) -> object | None:
         check.ensure_type(key, str)
 
         if not self.__doc:
             return None
         return self._get_or_none(self.__section, key) or self._get_or_none(ConfigReader.GLOBAL_SECTION, key)
 
-    def __call__(self, key: str):
+    def __call__(self, key: str) -> object | None:
         return self._get(key)

--- a/src/molim/images/imagemagick.py
+++ b/src/molim/images/imagemagick.py
@@ -51,7 +51,7 @@ class ImageMagickFileProcessor(shell.ShellCommandFileProcessor):
         *imagemagick_args: str,  # All args except for input and output file.
         output_strategy: processing.OutputFilePathStrategy,
         post_processor: processing.PostProcessingStrategy,
-    ):
+    ) -> None:
         super().__init__(
             "ImageMagick",
             "convert",

--- a/src/molim/images/rawtherapee.py
+++ b/src/molim/images/rawtherapee.py
@@ -162,7 +162,7 @@ class RawTherapeeFileProcessor(shell.ShellCommandFileProcessor):
         jpeg_subsampling: int,
         output_strategy: processing.OutputFilePathStrategy,
         post_processor: processing.PostProcessingStrategy,
-    ):
+    ) -> None:
         check.ensure_file(profile_path)
         check.ensure_int_between(jpeg_quality, 1, 100)
         check.ensure_int_between(jpeg_subsampling, 1, 3)

--- a/src/molim/images/resize.py
+++ b/src/molim/images/resize.py
@@ -108,7 +108,7 @@ class ResizeCommand(commands.Command, ImageMagickMixin):
         return processing.NoFileSkipStrategy()
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "resize"
 
     @property

--- a/src/molim/processing.py
+++ b/src/molim/processing.py
@@ -144,7 +144,7 @@ class FileProcessor:
         self.__output_strategy = output_strategy
         self.__post_processor = post_processor
 
-    def process(self, file_path: pathlib.Path, dry_run=False) -> stats.FileStats:
+    def process(self, file_path: pathlib.Path, dry_run: bool = False) -> stats.FileStats:
         check.ensure_file(file_path)
         with stats.FileStats(file_path) as statistics:
             output_file_path = self.__output_strategy.get_output_path(file_path)
@@ -281,7 +281,7 @@ class FolderProcessor:
         self.__file_skiper = file_skiper
         self.__file_processor = file_processor
 
-    def process(self, dry_run=False, show_size=True) -> stats.FolderStats:
+    def process(self, dry_run: bool = False, show_size: bool = True) -> stats.FolderStats:
         with stats.FolderStats(self.__folder_path) as statistics:
             files_list = []
             for f in self.__folder_path.iterdir():

--- a/src/molim/processing.py
+++ b/src/molim/processing.py
@@ -9,7 +9,7 @@ class OutputFilePathStrategy:
 
 
 class SuffixOutputFilePathStrategy(OutputFilePathStrategy):
-    def __init__(self, suffix: str):
+    def __init__(self, suffix: str) -> None:
         check.ensure_str_startswith(suffix, ".")
         self.__suffix = suffix
         show.normal(f"Processed files will get suffix '{suffix}'.")
@@ -21,7 +21,7 @@ class SuffixOutputFilePathStrategy(OutputFilePathStrategy):
 
 
 class ChangeExtOutputFilePathStrategy(OutputFilePathStrategy):
-    def __init__(self, ext: str):
+    def __init__(self, ext: str) -> None:
         check.ensure_str_startswith(ext, ".")
         self.__ext = ext
         show.normal(f"Processed files will have extension '{ext}'.")
@@ -36,7 +36,7 @@ class FolderOutputFilePathStrategy(OutputFilePathStrategy):
     Output strategy to put processed files into a different folder, not into the original folder.
     """
 
-    def __init__(self, target_folder: pathlib.Path, dry_run: bool):
+    def __init__(self, target_folder: pathlib.Path, dry_run: bool) -> None:
         check.ensure_path(target_folder)
         if target_folder.exists():
             check.ensure_folder(target_folder)
@@ -53,7 +53,7 @@ class FolderOutputFilePathStrategy(OutputFilePathStrategy):
 
 
 class MultiOutputFilePathStrategy(OutputFilePathStrategy):
-    def __init__(self, output_strategies: list[OutputFilePathStrategy]):
+    def __init__(self, output_strategies: list[OutputFilePathStrategy]) -> None:
         check.ensure_list_non_empty(output_strategies)
         self.__output_strategies = output_strategies
 
@@ -76,7 +76,7 @@ class NoopPostProcessingStrategy(PostProcessingStrategy):
 
 
 class MoveOriginalPostProcessingStrategy(PostProcessingStrategy):
-    def __init__(self, move_to: pathlib.Path, dry_run: bool):
+    def __init__(self, move_to: pathlib.Path, dry_run: bool) -> None:
         check.ensure_path(move_to)
         if move_to.exists():
             check.ensure_folder(move_to)
@@ -98,7 +98,7 @@ class MoveOriginalPostProcessingStrategy(PostProcessingStrategy):
 
 
 class DeleteOriginalPostProcessingStrategy(PostProcessingStrategy):
-    def __init__(self):
+    def __init__(self) -> None:
         show.normal("Original files will be deleted.")
 
     def process(self, input_filepath: pathlib.Path, output_filepath: pathlib.Path, dry_run: bool) -> None:
@@ -117,7 +117,7 @@ class ReplaceOriginalPostProcessignStrategy(PostProcessingStrategy):
     delete it or move to another location, or anything else.
     """
 
-    def __init__(self, originals_post_processor: PostProcessingStrategy):
+    def __init__(self, originals_post_processor: PostProcessingStrategy) -> None:
         check.ensure_type(originals_post_processor, PostProcessingStrategy)
         self.__originals_post_processor = originals_post_processor
         show.normal("Processed files will be renamed to the original file name.")
@@ -138,7 +138,7 @@ class FileProcessor:
         self,
         output_strategy: OutputFilePathStrategy,
         post_processor: PostProcessingStrategy,
-    ):
+    ) -> None:
         check.ensure_type(output_strategy, OutputFilePathStrategy)
         check.ensure_type(post_processor, PostProcessingStrategy)
         self.__output_strategy = output_strategy
@@ -183,7 +183,7 @@ class AnyFileMatchStrategy(FileMatchStrategy):
 
 
 class ByExtensionFileMatchStrategy(FileMatchStrategy):
-    def __init__(self, ext: str):
+    def __init__(self, ext: str) -> None:
         check.ensure_type(ext, str)
         ext_list = ext.split(",")
         for e in ext_list:
@@ -210,7 +210,7 @@ class NoFileSkipStrategy(FileSkipStrategy):
 
 
 class BySuffixFileSkipStrategy(FileSkipStrategy):
-    def __init__(self, suffix: str):
+    def __init__(self, suffix: str) -> None:
         check.ensure_str_startswith(suffix, ".")
         self.__suffix = suffix
 
@@ -223,7 +223,7 @@ class BySuffixFileSkipStrategy(FileSkipStrategy):
 
 
 class BySizeFileSkipStrategy(FileSkipStrategy):
-    def __init__(self, less_than: int):
+    def __init__(self, less_than: int) -> None:
         check.ensure_int_positive(less_than)
         self.__less_than = less_than
 
@@ -239,7 +239,7 @@ class BySizeFileSkipStrategy(FileSkipStrategy):
 
 
 class GlobFileSkipStrategy(FileSkipStrategy):
-    def __init__(self, glob_pattern: str):
+    def __init__(self, glob_pattern: str) -> None:
         check.ensure_type(glob_pattern, str)
         self.__glob_pattern = glob_pattern
 
@@ -252,7 +252,7 @@ class GlobFileSkipStrategy(FileSkipStrategy):
 
 
 class MultiFileSkipStrategy(FileSkipStrategy):
-    def __init__(self, skip_strategies: list[FileSkipStrategy]):
+    def __init__(self, skip_strategies: list[FileSkipStrategy]) -> None:
         check.ensure_type(skip_strategies, list)
         self.__skip_strategies = skip_strategies
 
@@ -271,7 +271,7 @@ class FolderProcessor:
         file_matcher: FileMatchStrategy,
         file_skiper: FileSkipStrategy,
         file_processor: FileProcessor,
-    ):
+    ) -> None:
         check.ensure_folder(folder_path)
         check.ensure_type(file_matcher, FileMatchStrategy)
         check.ensure_type(file_skiper, FileSkipStrategy)

--- a/src/molim/rename.py
+++ b/src/molim/rename.py
@@ -57,7 +57,7 @@ class RenameFileProcessor(processing.FileProcessor):
         self,
         output_strategy: processing.OutputFilePathStrategy,
         post_processor: processing.PostProcessingStrategy,
-    ):
+    ) -> None:
         super().__init__(output_strategy, post_processor)
 
     def _prepare_execution(self, file_path: pathlib.Path, output_file_path: pathlib.Path) -> None:

--- a/src/molim/rename.py
+++ b/src/molim/rename.py
@@ -40,7 +40,7 @@ class SuffixCommand(commands.Command):
         return processing.BySuffixFileSkipStrategy(args.SUFFIX)
 
     @property
-    def _show_size(self):
+    def _show_size(self) -> bool:
         return False
 
     @property

--- a/src/molim/shell.py
+++ b/src/molim/shell.py
@@ -8,7 +8,7 @@ from . import check, processing, show
 class ShellCommandNotFoundError(Exception):
     MESSAGE = "Could not run '{cmdline}' command. Check whether {name} is installed on your system and is available on PATH."
 
-    def __init__(self, cmdline: str, name: str):
+    def __init__(self, cmdline: str, name: str) -> None:
         self.message = ShellCommandNotFoundError.MESSAGE.format(cmdline=cmdline, name=name)
         super().__init__(self.message)
 
@@ -16,7 +16,7 @@ class ShellCommandNotFoundError(Exception):
 class ShellCommandRuntimeError(Exception):
     MESSAGE = "An error occurred during {name} execution. Exit code: {exit_code}. Command line: '{args}'"
 
-    def __init__(self, name: str, e: sh.ErrorReturnCode):
+    def __init__(self, name: str, e: sh.ErrorReturnCode) -> None:
         self.message = ShellCommandRuntimeError.MESSAGE.format(name=name, exit_code=e.exit_code, args=e.full_cmd)
         super().__init__(self.message)
 
@@ -29,7 +29,7 @@ class ShellCommandFileProcessor(processing.FileProcessor):
         *command_args: str,  # All args except for input and output file.
         output_strategy: processing.OutputFilePathStrategy,
         post_processor: processing.PostProcessingStrategy,
-    ):
+    ) -> None:
         super().__init__(output_strategy, post_processor)
         check.ensure_not_none(command_args)
         for a in command_args:

--- a/src/molim/show.py
+++ b/src/molim/show.py
@@ -1,3 +1,4 @@
+import argparse
 from datetime import timedelta
 
 import rich.console
@@ -57,7 +58,7 @@ def set_verbose(val: bool) -> None:
     __verbose = val
 
 
-def important(message: str, new_line=False) -> None:
+def important(message: str, new_line: bool = False) -> None:
     __CONSOLE__.print(message, style="bold", highlight=False, markup=False)
     if new_line:
         __CONSOLE__.print()
@@ -67,7 +68,7 @@ def rule(message: str = "") -> None:
     __CONSOLE__.rule(message)
 
 
-def normal(message: str, new_line=False) -> None:
+def normal(message: str, new_line: bool = False) -> None:
     __CONSOLE__.print(" " + message, highlight=False, markup=False)
     if new_line:
         __CONSOLE__.print()
@@ -80,7 +81,7 @@ def __delta(delta: int) -> str:
         return f"saved {human_size(delta)}"
 
 
-def file_stats(s, show_size: bool):
+def file_stats(s: object, show_size: bool) -> None:
     t = rich.text.Text(f"{s.original_file.name}")
     if show_size:
         t.append(
@@ -98,7 +99,7 @@ def file_stats(s, show_size: bool):
     __CONSOLE__.print(cols, highlight=False, markup=False)
 
 
-def folder_stats(s, show_size: bool):
+def folder_stats(s: object, show_size: bool) -> None:
     if s.processed_files_stats:
         important(
             f"Processed {len(s.processed_files_stats)} files in {elapsed(s.elapsed)}",
@@ -145,7 +146,7 @@ def verbose(message: str) -> None:
         __CONSOLE__.print("   " + message, style="grey50", highlight=False, markup=False)
 
 
-def verbose_args(args, new_line=False):
+def verbose_args(args: argparse.Namespace, new_line: bool = False) -> None:
     if __verbose:
         for k in args.__dict__:
             verbose(f" - {k} = {args.__dict__[k]}")

--- a/src/molim/stats.py
+++ b/src/molim/stats.py
@@ -1,5 +1,6 @@
 import pathlib
 import time
+from collections.abc import Callable
 
 from . import check, show
 
@@ -20,7 +21,7 @@ class StatsAlreadyFinishedError(Exception):
         super().__init__(self.message)
 
 
-def ensure_finished(method):
+def ensure_finished(method: Callable) -> Callable:
     def wrapper(self, *args, **kwargs):
         if not self.finished:
             raise StatsNotFinishedError()
@@ -29,7 +30,7 @@ def ensure_finished(method):
     return wrapper
 
 
-def ensure_not_finished(method):
+def ensure_not_finished(method: Callable) -> Callable:
     def wrapper(self, *args, **kwargs):
         if self.finished:
             raise StatsAlreadyFinishedError()
@@ -57,11 +58,16 @@ class Stats:
 
     # Support 'with' usage
 
-    def __enter__(self):
+    def __enter__(self) -> "Stats":
         self.start()
         return self
 
-    def __exit__(self, exception_type, exception_value, exception_traceback):
+    def __exit__(
+        self,
+        exception_type: type[BaseException] | None,
+        exception_value: BaseException | None,
+        exception_traceback: object,
+    ) -> None:
         self.finish()
 
     # Properties
@@ -105,7 +111,7 @@ class FileStats(Stats):
         self.__delta_size = None
 
     @ensure_not_finished
-    def set_processed_file(self, processed_file: pathlib.Path, processed_file_size: int = None):
+    def set_processed_file(self, processed_file: pathlib.Path, processed_file_size: int | None = None):
         if self.__processed_file:
             raise FileStatsAlreadyHaveProcessedFileError()
         if processed_file_size is not None:
@@ -115,7 +121,7 @@ class FileStats(Stats):
             self.__processed_file_size = processed_file.stat().st_size
         self.__processed_file = processed_file
 
-    def finish(self):
+    def finish(self) -> None:
         super().finish()
         if self.__processed_file_size is not None:
             self.__delta_size = self.__original_file_size - self.__processed_file_size
@@ -149,7 +155,7 @@ class FileStats(Stats):
 
     # __repr__
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.finished:
             return (
                 f"<FileStats(original_file={self.original_file}, "
@@ -220,7 +226,7 @@ class FolderStats(Stats):
 
     # __repr__
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.finished:
             return (
                 f"<FolderStats(folder_path={self.folder_path}, "

--- a/src/molim/stats.py
+++ b/src/molim/stats.py
@@ -8,7 +8,7 @@ from . import check, show
 class StatsNotFinishedError(Exception):
     DEFAULT_MESSAGE = "Statistics results should not be accessed before gathering is finished yet."
 
-    def __init__(self, message=DEFAULT_MESSAGE):
+    def __init__(self, message: str = DEFAULT_MESSAGE) -> None:
         self.message = message
         super().__init__(self.message)
 
@@ -16,13 +16,13 @@ class StatsNotFinishedError(Exception):
 class StatsAlreadyFinishedError(Exception):
     DEFAULT_MESSAGE = "Statistics gathering is already finished, cannot finish again."
 
-    def __init__(self, message=DEFAULT_MESSAGE):
+    def __init__(self, message: str = DEFAULT_MESSAGE) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 def ensure_finished(method: Callable) -> Callable:
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: object, *args: object, **kwargs: object) -> object:
         if not self.finished:
             raise StatsNotFinishedError()
         return method(self, *args, **kwargs)
@@ -31,7 +31,7 @@ def ensure_finished(method: Callable) -> Callable:
 
 
 def ensure_not_finished(method: Callable) -> Callable:
-    def wrapper(self, *args, **kwargs):
+    def wrapper(self: object, *args: object, **kwargs: object) -> object:
         if self.finished:
             raise StatsAlreadyFinishedError()
         return method(self, *args, **kwargs)
@@ -40,7 +40,7 @@ def ensure_not_finished(method: Callable) -> Callable:
 
 
 class Stats:
-    def __init__(self):
+    def __init__(self) -> None:
         self.__start_ts = None
         self.__end_ts = None
         self.__elapsed = None
@@ -95,13 +95,13 @@ class Stats:
 class FileStatsAlreadyHaveProcessedFileError(Exception):
     DEFAULT_MESSAGE = "The processed file was already provided."
 
-    def __init__(self, message=DEFAULT_MESSAGE):
+    def __init__(self, message: str = DEFAULT_MESSAGE) -> None:
         self.message = message
         super().__init__(self.message)
 
 
 class FileStats(Stats):
-    def __init__(self, original_file: pathlib.Path):
+    def __init__(self, original_file: pathlib.Path) -> None:
         super().__init__()
         check.ensure_file(original_file)
         self.__original_file = original_file
@@ -170,7 +170,7 @@ class FileStats(Stats):
 
 
 class FolderStats(Stats):
-    def __init__(self, folder_path: pathlib.Path):
+    def __init__(self, folder_path: pathlib.Path) -> None:
         super().__init__()
         check.ensure_folder(folder_path)
         self.__folder_path = folder_path

--- a/src/molim/video.py
+++ b/src/molim/video.py
@@ -41,7 +41,7 @@ class VideoFfmpegCommand(commands.Command):
         )
         return parser
 
-    def _get_common_arguments_defaults(self) -> tuple[str, str, str]:
+    def _get_common_arguments_defaults(self) -> tuple[str, str, bool, str]:
         return (
             VideoFfmpegCommand.EXTENSION,
             VideoFfmpegCommand.GREATER_THAN,

--- a/src/molim/video.py
+++ b/src/molim/video.py
@@ -106,7 +106,7 @@ class FfmpegFileProcessor(shell.ShellCommandFileProcessor):
         ffmpeg_report: bool,
         output_strategy: processing.OutputFilePathStrategy,
         post_processor: processing.PostProcessingStrategy,
-    ):
+    ) -> None:
         check.ensure_type(ffmpeg_codec, str)
         check.ensure_int_between(ffmpeg_rate, 0, 51)
         check.ensure_type_or_none(ffmpeg_additional, str)


### PR DESCRIPTION
## Summary

- Adds parameter and return type annotations to all previously unannotated function and method signatures in `src/molim/`
- Fixes `video.py` `_get_common_arguments_defaults` return type (`tuple[str, str, str]` → `tuple[str, str, bool, str]`)
- Fixes `stats.py` `processed_file_size: int = None` → `int | None = None`

## Test plan

- [x] `uv run ruff format .` passes
- [x] `uv run ruff check .` passes
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)