### PR TITLE
Validate bootstrap tools availability in entrypoint.sh

### DIFF
--- a/.devcontainer/claude-dev/entrypoint.sh
+++ b/.devcontainer/claude-dev/entrypoint.sh
@@ -78,6 +78,14 @@ require_env() {
     success "$text"
 }
 
+require_tool() {
+    local tool="$1"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        die "tool '${tool}' not found in PATH. Container image does not match entrypoint.sh prerequisites; cannot proceed."
+    fi
+    success "$tool"
+}
+
 require_env GITHUB_OWNER true
 require_env GITHUB_REPO true
 require_env GITHUB_TOKEN_
@@ -86,6 +94,18 @@ require_env TZ true
 require_env CLAUDE_DEV_PROXY_SOCKET
 require_env CLAUDE_DEV_PROXY_PORT
 require_env CLAUDE_CODE_VERSION true
+
+require_tool socat
+require_tool gh
+require_tool git
+require_tool jq
+require_tool uv
+require_tool claude
+require_tool rg
+require_tool fdfind
+require_tool bwrap
+require_tool micro
+require_tool delta
 
 # ----------------------------------------------------------------------
 # Issue ID handling


### PR DESCRIPTION
Closes nightjarrr/adda-dev-runtime#20

## Summary
- Added `require_tool` helper to `entrypoint.sh` (mirrors `require_tool` in `claude-dev.sh`, but with a fixed container-image-mismatch message and a `success` line on the happy path)
- Added 11 tool checks in the "Validating environment" section, after `require_env` calls: `socat`, `gh`, `git`, `jq`, `uv`, `claude`, `rg`, `fdfind`, `bwrap`, `micro`, `delta`
- Project-specific tools (`rawtherapee-cli`, `convert`, `ffmpeg`) are excluded pending the base/project container split

## Test plan
- [ ] Normal container start: each tool prints `✓ <tool>` in the Validating environment section
- [ ] Simulate missing tool: rename a binary off PATH, re-run entrypoint — expect the fixed die message and early exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)