### PR TITLE
Redirect Claude auto memory to in-repo .claude/memory/

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,1 +1,3 @@
 <!-- Claude Code auto memory index. Managed by Claude; do not edit manually. -->
+
+- [Do not invoke update-config when entering plan mode](feedback_plan_mode.md) — invoking update-config before EnterPlanMode is a mistake; use EnterPlanMode directly

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,1 @@
+<!-- Claude Code auto memory index. Managed by Claude; do not edit manually. -->

--- a/.claude/memory/feedback_plan_mode.md
+++ b/.claude/memory/feedback_plan_mode.md
@@ -1,0 +1,11 @@
+---
+name: Do not invoke update-config when entering plan mode
+description: Entering plan mode (EnterPlanMode tool) does not require the update-config skill — do not invoke it
+type: feedback
+originSessionId: 8018a590-8ea2-4cbf-84a1-26ef2910b208
+---
+Do not invoke the `update-config` skill when trying to enter plan mode as part of proto-SDLC step 3.
+
+**Why:** Happened at least twice — the skill was invoked by mistake before entering plan mode, causing an unnecessary permission prompt for the user. The `update-config` skill is for modifying `settings.json`; entering plan mode uses the `EnterPlanMode` tool directly.
+
+**How to apply:** When step 3 of proto-SDLC says "enter plan mode", call the `EnterPlanMode` tool directly. Do not invoke any skill first.

--- a/.devcontainer/claude-dev/Dockerfile
+++ b/.devcontainer/claude-dev/Dockerfile
@@ -132,6 +132,7 @@ RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
 # Source of truth for CLAUDE_CODE_VERSION is the ENV declaration above.
 # ----------------------------------------------------------------------
 COPY .devcontainer/claude-dev/.claude.json.template /etc/claude-dev/.claude.json.template
+COPY .devcontainer/claude-dev/settings.json.template /etc/claude-dev/settings.json.template
 
 # ----------------------------------------------------------------------
 # Bootstrap entrypoint script

--- a/.devcontainer/claude-dev/entrypoint.sh
+++ b/.devcontainer/claude-dev/entrypoint.sh
@@ -669,6 +669,20 @@ echo "lastOnboardingVersion: ${CLAUDE_CODE_VERSION}"
 mkdir -p "${HOME}/.claude"
 success "Initialized ~/.claude.json."
 
+# ----------------------------------------------------------------------
+# Write ~/.claude/settings.json
+# Configures user-level Claude Code settings that cannot live in the
+# project's .claude/settings.json (security restriction). Currently
+# sets autoMemoryDirectory to redirect auto memory into the cloned
+# repo so memory survives container restarts via git.
+# Template lives at /etc/claude-dev/settings.json.template.
+# ----------------------------------------------------------------------
+section "Initializing Claude user settings in ~/.claude/settings.json"
+
+cp /etc/claude-dev/settings.json.template "${HOME}/.claude/settings.json"
+chmod 600 "${HOME}/.claude/settings.json"
+success "Initialized ~/.claude/settings.json."
+
 # ======================================================================
 # PROJECT — molim-specific dependency installation
 # ======================================================================

--- a/.devcontainer/claude-dev/entrypoint.sh
+++ b/.devcontainer/claude-dev/entrypoint.sh
@@ -681,6 +681,7 @@ section "Initializing Claude user settings in ~/.claude/settings.json"
 
 cp /etc/claude-dev/settings.json.template "${HOME}/.claude/settings.json"
 chmod 600 "${HOME}/.claude/settings.json"
+mkdir -p /workspace/.claude/memory
 success "Initialized ~/.claude/settings.json."
 
 # ======================================================================

--- a/.devcontainer/claude-dev/settings.json.template
+++ b/.devcontainer/claude-dev/settings.json.template
@@ -1,0 +1,3 @@
+{
+    "autoMemoryDirectory": "/workspace/.claude/memory"
+}

--- a/docs/CURRENT-STATE.md
+++ b/docs/CURRENT-STATE.md
@@ -219,9 +219,12 @@ Policy clarification:
 * Clones repo into `/workspace`.
 * Resolves linked GitHub issue branch via GraphQL `linkedBranches(first: 2)`.
 * Initializes `~/.claude.json` from template using `CLAUDE_CODE_VERSION`.
+* Writes `~/.claude/settings.json` from `/etc/claude-dev/settings.json.template`; sets `autoMemoryDirectory` to `/workspace/.claude/memory`.
 * Runs project bootstrap currently via `uv sync --frozen`.
 * Runs CMD (`claude` by default), then drops to interactive bash.
 * On exit, prints git status and commits ahead of upstream/main.
+
+`.claude/memory/` is the in-repo auto memory directory. Memory files are committed to the current feature branch and merged to `main` via the normal PR lifecycle — the same lifecycle as subagent memory (`agent-memory/`).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/claude-dev/settings.json.template` — user-level Claude Code settings template, following the existing `.claude.json.template` pattern
- Bakes the template into the Docker image at `/etc/claude-dev/settings.json.template`; entrypoint writes it to `~/.claude/settings.json` at bootstrap, setting `autoMemoryDirectory` to `/workspace/.claude/memory`
- Seeds `.claude/memory/MEMORY.md` in the repo so the directory exists after every fresh clone

## Why

Both `/home/node` and `/workspace` are ephemeral tmpfs mounts — wiped on container exit. Auto memory was stored in `~/.claude/projects/…/memory/` (on tmpfs), so every session-accumulated learning was lost. This redirects memory into the cloned repo, where it lives alongside all other project content, gets committed to feature branches, reviewed in PRs, and lands on `main` via merge. Same lifecycle as subagent memory — consistent design across both.

`autoMemoryDirectory` cannot live in `.claude/settings.json` (project settings) due to a Claude Code security restriction; it must be in user settings, which is why the entrypoint writes `~/.claude/settings.json` fresh from the template each container start.

## Test plan

- [x] Build the image and confirm `/etc/claude-dev/settings.json.template` is present
- [x] Run the container and confirm `~/.claude/settings.json` exists with correct `autoMemoryDirectory` value
- [x] Start a Claude session, make a correction; confirm memory writes appear in `/workspace/.claude/memory/`
- [x] Confirm `.claude/memory/` shows in `git status` as modified after a session

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)