### PR TITLE
Add Add Changelog Entry skill (#70)

### DIFF
--- a/.devcontainer/claude-dev/settings.json.template
+++ b/.devcontainer/claude-dev/settings.json.template
@@ -1,3 +1,9 @@
 {
-    "autoMemoryDirectory": "/workspace/.claude/memory"
+    "autoMemoryDirectory": "/workspace/.claude/memory",
+    "permissions": {
+        "allow": [
+            "Bash(node scripts/add-changelog-entry.mjs *)",
+            "Bash(scripts/add-changelog-entry.mjs *)"
+        ]
+    }
 }

--- a/docs/AGENTIC-SDLC.md
+++ b/docs/AGENTIC-SDLC.md
@@ -231,7 +231,6 @@ The skill writes only to `CHANGELOG.md`. The invoking agent (AA) handles the com
 - **Outputs:** `PASS` or `FAIL` per check printed to stdout with progress; path to a JSON result file containing per-check status and full output for all checks.
 - **Permissions required:** `shell:exec`, `fs:read`, `fs:write`.
 - **Invoked by:** Coder, in Phase 5.
-- **Implementation:** Bash script at `scripts/quality-gates.sh`. Not a model-based skill — deterministic, zero LLM cost.
 
 `fs:write` access is required for formatting and linting tools to modify codebase and for tests to store any output artifacts (e.g. coverage report).
 

--- a/scripts/add-changelog-entry.mjs
+++ b/scripts/add-changelog-entry.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+
+import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+const { values } = parseArgs({
+    options: {
+        'issue-id': { type: 'string' },
+        'entry': { type: 'string' },
+    },
+    strict: true,
+});
+
+const { 'issue-id': issueId, entry: entryText } = values;
+
+if (!issueId || !issueId.trim()) {
+    process.stderr.write('Error: --issue-id is required and must be non-empty.\n');
+    process.exit(2);
+}
+
+if (!entryText || !entryText.trim()) {
+    process.stderr.write('Error: --entry is required and must be non-empty.\n');
+    process.exit(2);
+}
+
+const repoRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+const changelogPath = join(repoRoot, 'CHANGELOG.md');
+
+const SKELETON = '# Changelog\n\n## UPCOMING\n\n';
+
+let raw = '';
+try {
+    raw = readFileSync(changelogPath, 'utf8');
+} catch {
+    // file absent — will bootstrap below
+}
+
+if (!raw.trim()) {
+    writeFileSync(changelogPath, SKELETON, 'utf8');
+    raw = readFileSync(changelogPath, 'utf8');
+}
+
+const lines = raw.split('\n');
+
+const upcomingIdx = lines.findIndex(l => l === '## UPCOMING');
+if (upcomingIdx === -1) {
+    process.stderr.write('Error: CHANGELOG.md exists and is non-empty but contains no "## UPCOMING" section.\n');
+    process.exit(1);
+}
+
+const nextSectionRaw = lines.findIndex((l, i) => i > upcomingIdx && l.startsWith('## '));
+// When no next section exists (pre-release), treat EOF as boundary.
+// Account for the trailing-newline artifact: split('\n') on a file ending with '\n'
+// produces a final empty element that represents the newline, not a blank line.
+const atEof = nextSectionRaw === -1;
+const nextSectionIdx = atEof ? lines.length : nextSectionRaw;
+
+// Effective boundary excludes the trailing-newline artifact when at EOF
+const effectiveBoundary = atEof && lines[lines.length - 1] === '' ? lines.length - 1 : nextSectionIdx;
+
+const sectionLines = lines.slice(upcomingIdx + 1, effectiveBoundary);
+const isEmpty = sectionLines.every(l => l.trim() === '');
+
+const entry = `- ${entryText} (#${issueId})`;
+
+if (isEmpty) {
+    // Insert entry + trailing blank before the effective boundary.
+    // For real next sections: splice at nextSectionIdx (inserts before the section header).
+    // For EOF: splice at effectiveBoundary (inserts before the trailing-newline artifact),
+    // and add a trailing blank to maintain the blank-line-before-EOF convention.
+    lines.splice(effectiveBoundary, 0, entry, '');
+} else {
+    lines.splice(nextSectionIdx - 1, 0, entry);
+}
+
+writeFileSync(changelogPath, lines.join('\n'), 'utf8');
+
+// Re-find boundaries in updated array to output the UPCOMING section
+const updatedUpcomingIdx = lines.findIndex(l => l === '## UPCOMING');
+const updatedNextSectionRaw = lines.findIndex((l, i) => i > updatedUpcomingIdx && l.startsWith('## '));
+const updatedNextSectionIdx = updatedNextSectionRaw === -1 ? lines.length : updatedNextSectionRaw;
+
+const outputLines = lines.slice(updatedUpcomingIdx, updatedNextSectionIdx);
+// Trim trailing blank lines from output
+while (outputLines.length > 0 && outputLines[outputLines.length - 1].trim() === '') {
+    outputLines.pop();
+}
+
+process.stdout.write(outputLines.join('\n') + '\n');


### PR DESCRIPTION
## Summary

- Adds `scripts/add-changelog-entry.mjs` — Node.js 24+ ESM script that appends a user-facing entry to the `## UPCOMING` section of `CHANGELOG.md`, invoked directly by the Associate Architect agent in Phase 6
- Adds SDLC-level permission entries to `.devcontainer/claude-dev/settings.json.template` (both `node` and direct shebang invocation)
- Removes implementation detail from the Quality Gates skill entry in `docs/AGENTIC-SDLC.md` — SDLC doc is now impl-agnostic

This issue also establishes the **Node.js script pattern for SDLC tooling**: `.mjs` extension, `node:` import prefix, `parseArgs` from `node:util`, Node.js 24+ target, exit 2 for usage errors. See issue #70 for the full rationale and pattern reference.

## Test plan

- [x] `node scripts/add-changelog-entry.mjs --issue-id 70 --entry "Some entry."` — stdout shows UPCOMING section with entry, CHANGELOG updated correctly
- [x] Run twice — second entry appends after the first with correct blank-line structure
- [x] Bootstrap: missing or empty CHANGELOG.md → skeleton created, entry inserted, exit 0
- [x] Pre-release (no `## v…` sections): entry appended at EOF, exit 0
- [x] Wrong format (no `## UPCOMING` in non-empty file): stderr + exit 1
- [x] `git checkout CHANGELOG.md` to restore after manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)