### PR TITLE
Fix intermittent CI failure due to missing libheif in ubuntu-latest runner

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -23,7 +23,7 @@ jobs:
         run: uv sync --all-extras --dev
 
       - name: Install CLI tools
-        run: sudo apt-get install -y --no-install-recommends rawtherapee imagemagick ffmpeg
+        run: sudo apt-get install -y --no-install-recommends rawtherapee imagemagick ffmpeg libheif1 libheif-plugin-libde265
 
       - name: Run tests
         run: uv run pytest


### PR DESCRIPTION
Fixes #140

## Summary
- Adds `libheif1` and `libheif-plugin-libde265` to the "Install CLI tools" apt install step in `.github/workflows/base.yml`
- Ubuntu 24.04 (now resolved by `ubuntu-latest`) moved libheif to a plugin architecture — codec plugins are no longer bundled, causing ImageMagick to lose HEIC support when `libheif-plugin-libde265` is absent

## Test plan
- [x] CI run on feature branch passed (run `25911219056`)
- [x] `test_JpegifyCommand_core_logic` (processes `.heic` test fixtures) covered by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)